### PR TITLE
fix: Configure PyPI publishing with TestPyPI gating

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  test-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for setuptools_scm
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      
+      - name: Build package
+        run: python -m build
+      
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+
   publish:
     runs-on: ubuntu-latest
+    needs: test-publish
     environment: publish
     permissions:
       id-token: write  # Required for trusted publishing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish
     permissions:
       id-token: write  # Required for trusted publishing
     steps:


### PR DESCRIPTION
## Summary

Fixes PyPI publishing by adding the required `publish` environment to the workflow and implementing TestPyPI gating.

## Changes

- Add `environment: publish` to PyPI publish job to match Trusted Publisher config
- Add TestPyPI publish job that runs first for validation  
- PyPI publish only runs if TestPyPI succeeds (gated deployment)
- TestPyPI uses no environment, PyPI uses `publish` environment

## Testing

This should fix the previous publishing failure:
```
invalid-publisher: valid token, but no corresponding publisher
```

The workflow will now:
1. Publish to TestPyPI first
2. If successful, publish to PyPI (with environment protection)

🤖 Generated with [Claude Code](https://claude.ai/code)