### PR TITLE
docs: add tmp/ folder for gitignored test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ src/louieai/_version.py
 # Planning and temporary files
 AI_PROGRESS/
 plans/
+tmp/

--- a/ai/README.md
+++ b/ai/README.md
@@ -47,6 +47,7 @@ pytest
 
 - **NEVER** commit credentials or API keys
 - Use `.env` files for test credentials (already in .gitignore)
+- Use `tmp/` folder for temporary test scripts with credentials (already in .gitignore)
 - Check for sensitive data before commits
 - Use secure token handling patterns
 
@@ -84,7 +85,8 @@ louie-py/
 │   └── integration/     # Integration tests (real API)
 ├── docs/                # MkDocs documentation
 ├── scripts/             # Development scripts
-└── ai/                  # AI assistant resources
+├── ai/                  # AI assistant resources
+└── tmp/                 # Temporary test files (gitignored)
 ```
 
 ## Response Types


### PR DESCRIPTION
## Summary
- Add `tmp/` folder to .gitignore for temporary test scripts that may contain credentials
- Document the tmp/ folder usage in ai/README.md under security best practices
- Update project structure documentation to include tmp/ directory

This provides a safe location for test scripts with credentials that won't accidentally be committed to the repository.

## Test plan
- [x] Verify tmp/ is properly gitignored
- [x] Documentation is clear about the purpose of tmp/ folder