### PR TITLE
docs: fix README issues and documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,23 @@ import louieai as lui
 # Authenticate with your Graphistry account
 graphistry.register(api=3, username="your_user", password="your_pass")
 
-# Create a client and ask questions
+# Create a client and make queries
 client = lui.Client()
-response = client.ask("Show me patterns in the security logs")
+response = client.add_cell("", "Show me patterns in the security logs")
 
 # Access different response types
 for text in response.text_elements:
     print(text['text'])
     
-for df in response.df_elements:
+for df in response.dataframe_elements:
     print(df['table'])  # pandas DataFrame
 ```
 
 ## Documentation
 
-- [User Guide](https://louieai.readthedocs.io) - Complete usage examples and tutorials
-- [API Reference](https://louieai.readthedocs.io/en/latest/api/) - Detailed API documentation
-- [Examples](https://louieai.readthedocs.io/en/latest/examples/) - Common patterns and use cases
+- [User Guide](https://louie-py.readthedocs.io) - Complete usage examples and tutorials
+- [API Reference](https://louie-py.readthedocs.io/en/latest/api/) - Detailed API documentation
+- [Examples](https://louie-py.readthedocs.io/en/latest/examples/) - Common patterns and use cases
 
 ## Links
 
@@ -70,5 +70,3 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 ## License
 
 Apache 2.0 - see [LICENSE](LICENSE)
-
-The Apache-2.0 license enables easy integration in enterprise environments, Splunk apps, and Jupyter notebooks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: LouieAI Client
 site_description: Documentation for the LouieAI Python client library.
-site_url: https://louieai.readthedocs.io
+site_url: https://louie-py.readthedocs.io
 nav:
   - Home: index.md
   - Architecture: architecture.md


### PR DESCRIPTION
## Summary
- Fix outdated API examples in Quick Start section
- Update documentation URLs to correct ReadTheDocs domain
- Remove confusing Apache license comment

## Changes
1. **Fix API usage**: 
   - Change `client.ask()` to `client.add_cell("", ...)` (ask method was removed)
   - Change `response.df_elements` to `response.dataframe_elements`
2. **Fix documentation URLs**:
   - Update from `louieai.readthedocs.io` to `louie-py.readthedocs.io`
   - Also update `mkdocs.yml` site_url to match
3. **Clean up license section**:
   - Remove the odd comment about "enables easy integration in enterprise environments, Splunk apps, and Jupyter notebooks"

## Test plan
- [x] Verified louie-py.readthedocs.io returns 302 (exists)
- [x] Verified louieai.readthedocs.io returns 404 (doesn't exist)
- [x] Code examples match current API