### PR TITLE
fix: lower pyarrow requirement for Colab compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "graphistry>=0.41.0",
   "httpx>=0.28.0",
   "pandas>=2.0.0",
-  "pyarrow>=21.0.0"
+  "pyarrow>=14.0.0"
 ]
 # Note: graphistry on PyPI is named 'graphistry'. We ensure a minimal version that likely includes Louie support.
 

--- a/uv.lock
+++ b/uv.lock
@@ -435,7 +435,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
-    { name = "pyarrow", specifier = ">=21.0.0" },
+    { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },


### PR DESCRIPTION
## Summary
Fixes the pyarrow dependency conflict that prevents `pip install louieai` from working in Google Colab.

## Problem
Google Colab has pre-installed CUDA libraries that require pyarrow<20.0.0:
- `cudf-cu12` requires `pyarrow<20.0.0a0,>=14.0.0`
- `pylibcudf-cu12` requires `pyarrow<20.0.0a0,>=14.0.0`

Our requirement of `pyarrow>=21.0.0` conflicts with these, causing installation errors.

## Solution
Lower our pyarrow requirement from `>=21.0.0` to `>=14.0.0`

## Investigation Results
1. **No direct pyarrow usage** - We don't import pyarrow directly in our codebase
2. **Graphistry compatibility** - graphistry 0.41.0 has no explicit pyarrow requirement
3. **Test results** - All unit tests pass with pyarrow 19.0.0
4. **Arrow stability** - PyArrow is a stable standard, our usage is minimal

## Test Plan
- [x] Unit tests pass with pyarrow 19.0.0
- [x] Code coverage maintained at 99%
- [x] Graphistry loads successfully with pyarrow 19
- [ ] Manual test in Google Colab after merge

## Colab Test Command
```python
\!pip install louieai
import louieai as lui
# Should install without conflicts
```

Fixes the installation issue reported in Colab with Python 3.11