### PR TITLE
fix: resolve ruff line length violation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,14 @@ ignore_missing_imports = true
 module = "pyarrow"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "httpx"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "IPython.*"
+ignore_missing_imports = true
+
 # Ignore mypy issues in test files for complex mocking
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/tests/integration/test_notebook_experience.py
+++ b/tests/integration/test_notebook_experience.py
@@ -74,7 +74,9 @@ class TestNotebookExperience:
             # History access works
             # lui[-1] gives ResponseProxy for the latest response
             assert lui[-1].text == "Here's your data analysis:"
-            assert lui[-2].text == "Here's a song for you:\n\nTwinkle twinkle little star"
+            assert lui[-2].text == (
+                "Here's a song for you:\n\nTwinkle twinkle little star"
+            )
 
     def test_notebook_display_modes(self):
         """Test different display scenarios in notebooks."""


### PR DESCRIPTION
## Summary
- Fixed line too long error in test_notebook_experience.py by breaking long assertion into multiple lines
- Added missing mypy overrides for httpx and IPython modules

## Test plan
- [x] Run `./scripts/ruff.sh check --fix` - passes cleanly
- [x] Verify code formatting follows project standards

🤖 Generated with [Claude Code](https://claude.ai/code)