### PR TITLE
fix: update vibes tutorial to use correct Databricks table name

### DIFF
--- a/docs/getting-started/notebooks/05-vibes-investigation-tutorial.ipynb
+++ b/docs/getting-started/notebooks/05-vibes-investigation-tutorial.ipynb
@@ -37,10 +37,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:25.695823Z",
-     "iopub.status.busy": "2025-08-04T02:30:25.695643Z",
-     "iopub.status.idle": "2025-08-04T02:30:26.354471Z",
-     "shell.execute_reply": "2025-08-04T02:30:26.353577Z"
+     "iopub.execute_input": "2025-08-04T04:31:31.170034Z",
+     "iopub.status.busy": "2025-08-04T04:31:31.169849Z",
+     "iopub.status.idle": "2025-08-04T04:31:31.832168Z",
+     "shell.execute_reply": "2025-08-04T04:31:31.831485Z"
     },
     "id": "UMxOEdMWm8sb"
    },
@@ -76,10 +76,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:26.356441Z",
-     "iopub.status.busy": "2025-08-04T02:30:26.356229Z",
-     "iopub.status.idle": "2025-08-04T02:30:26.653833Z",
-     "shell.execute_reply": "2025-08-04T02:30:26.653579Z"
+     "iopub.execute_input": "2025-08-04T04:31:31.834327Z",
+     "iopub.status.busy": "2025-08-04T04:31:31.834107Z",
+     "iopub.status.idle": "2025-08-04T04:31:32.131820Z",
+     "shell.execute_reply": "2025-08-04T04:31:32.131521Z"
     },
     "id": "L205f3Km2kZq",
     "outputId": "ccac75e1-40b5-4328-cc57-435a5b673955"
@@ -89,7 +89,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphistry 0.41.0 louieai 0.5.3.dev1+g49851b1.d20250804\n"
+      "graphistry 0.41.0 louieai 0.5.3.dev12+g11e4bae.d20250804\n"
      ]
     }
    ],
@@ -122,10 +122,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:26.655086Z",
-     "iopub.status.busy": "2025-08-04T02:30:26.654944Z",
-     "iopub.status.idle": "2025-08-04T02:30:27.399009Z",
-     "shell.execute_reply": "2025-08-04T02:30:27.398481Z"
+     "iopub.execute_input": "2025-08-04T04:31:32.133295Z",
+     "iopub.status.busy": "2025-08-04T04:31:32.133150Z",
+     "iopub.status.idle": "2025-08-04T04:31:32.897927Z",
+     "shell.execute_reply": "2025-08-04T04:31:32.897586Z"
     },
     "id": "yrMsAm9p0fjO",
     "outputId": "bb497580-608f-4ffb-c89d-c28c38b3c8ee"
@@ -208,10 +208,10 @@
      "height": 398
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:27.400101Z",
-     "iopub.status.busy": "2025-08-04T02:30:27.399985Z",
-     "iopub.status.idle": "2025-08-04T02:30:34.913670Z",
-     "shell.execute_reply": "2025-08-04T02:30:34.913256Z"
+     "iopub.execute_input": "2025-08-04T04:31:32.898909Z",
+     "iopub.status.busy": "2025-08-04T04:31:32.898801Z",
+     "iopub.status.idle": "2025-08-04T04:31:37.862548Z",
+     "shell.execute_reply": "2025-08-04T04:31:37.862094Z"
     },
     "id": "_671sJKdlGTZ",
     "outputId": "951d0080-250f-47ed-faec-f8b533f8bee7"
@@ -220,7 +220,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_LISJ0vRhgOwSJtEykymY</code> | Time: 7.5s</div><div style='margin-top: 10px;'><div id='B_2vILSHMy'>🎶 Woof woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, with Louie the data dog, we'll</div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_rQCYqfb7zn2InVBYWT1b</code> | Time: 5.0s</div><div style='margin-top: 10px;'><div id='B_M7Ufr1lX'>🎶 Woof, woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, Louie's</div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -234,9 +234,9 @@
       "text/html": [
        "<div style='border: 1px solid #ddd; padding: 10px; border-radius: 5px; margin-bottom: 10px;'>\n",
        "<h4 style='margin-top: 0;'>🤖 LouieAI Response</h4>\n",
-       "<div>🎶 Woof woof, I&#x27;m Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I&#x27;ll fetch your data day and night. Queries, graphs, and dashboards too, I&#x27;ll make your data dreams come true. So let&#x27;s dive in, don&#x27;t delay, with Louie the data dog, we&#x27;ll</div>\n",
+       "<div>🎶 Woof, woof, I&#x27;m Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I&#x27;ll fetch your data day and night. Queries, graphs, and dashboards too, I&#x27;ll make your data dreams come true. So let&#x27;s dive in, don&#x27;t delay, Louie&#x27;s</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_LISJ0vRhgOwSJtEykymY</code> | <a href='https://louie.graphistry.com/?dthread=D_LISJ0vRhgOwSJtEykymY' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_rQCYqfb7zn2InVBYWT1b</code> | <a href='https://louie.graphistry.com/?dthread=D_rQCYqfb7zn2InVBYWT1b' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 1 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
@@ -309,10 +309,10 @@
      "height": 433
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:34.915040Z",
-     "iopub.status.busy": "2025-08-04T02:30:34.914833Z",
-     "iopub.status.idle": "2025-08-04T02:30:41.307711Z",
-     "shell.execute_reply": "2025-08-04T02:30:41.307358Z"
+     "iopub.execute_input": "2025-08-04T04:31:37.864441Z",
+     "iopub.status.busy": "2025-08-04T04:31:37.864253Z",
+     "iopub.status.idle": "2025-08-04T04:31:46.966224Z",
+     "shell.execute_reply": "2025-08-04T04:31:46.965790Z"
     },
     "id": "xeSGCpuhm9yV",
     "outputId": "bac7e0e2-d349-411a-f69f-67694d6a8f50"
@@ -321,7 +321,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_LISJ0vRhgOwSJtEykymY</code> | Time: 6.4s</div><div style='margin-top: 10px;'><div id='B_QBg5Qeb6'>🎶 Oof-way oof-way, I'm-ay Ouie-lay, the-ay ata-day og-day, asing-chay ata-day ough-thray the-ay og-fay. Ith-way a-ay ag-way of-ay y-may ail-tay and-ay a-ay ark-bay o-say ight-bray, I'll-ay etch-fay our-yay ata-day ay-day and-ay ight-nay. Ueries-qay, aphs-gray, and-ay ashboards-day oo-tay, I'll-ay ake-may our-yay ata-day eams-dray ome-cay ue-tray. O-say et's-lay ive-day in-ay, on't-day elay-day, ith-way Ouie-lay the-ay ata-day og-day, e'll-way ave</div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_rQCYqfb7zn2InVBYWT1b</code> | Time: 9.1s</div><div style='margin-top: 10px;'><div id='B_mon4hTrS'>🎶 Oof-way, oof-way, I'm-way Ouie-lay, the-way ata-day og-day, asing-chay ata-day ough-thray the-way og-fay. Ith-way a-way ag-way of-way y-may ail-tay and-way a-way ark-bay o-say ight-bray, I'll-way etch-fay our-yay ata-day ay-day and-way ight-nay. Ueries-qay, aphs-gray, and-way ashboards-day oo-tay, I'll-way ake-may our-yay ata-day eams-dray ome-cay ue-tray. O-say et's-lay ive-day in-way, on't-day elay-day, Ouie-lay's ere-hay to-way ave</div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -335,9 +335,9 @@
       "text/html": [
        "<div style='border: 1px solid #ddd; padding: 10px; border-radius: 5px; margin-bottom: 10px;'>\n",
        "<h4 style='margin-top: 0;'>🤖 LouieAI Response</h4>\n",
-       "<div>🎶 Oof-way oof-way, I&#x27;m-ay Ouie-lay, the-ay ata-day og-day, asing-chay ata-day ough-thray the-ay og-fay. Ith-way a-ay ag-way of-ay y-may ail-tay and-ay a-ay ark-bay o-say ight-bray, I&#x27;ll-ay etch-fay our-yay ata-day ay-day and-ay ight-nay. Ueries-qay, aphs-gray, and-ay ashboards-day oo-tay, I&#x27;ll-ay ake-may our-yay ata-day eams-dray ome-cay ue-tray. O-say et&#x27;s-lay ive-day in-ay, on&#x27;t-day elay-day, ith-way Ouie-lay the-ay ata-day og-day, e&#x27;ll-way ave</div>\n",
+       "<div>🎶 Oof-way, oof-way, I&#x27;m-way Ouie-lay, the-way ata-day og-day, asing-chay ata-day ough-thray the-way og-fay. Ith-way a-way ag-way of-way y-may ail-tay and-way a-way ark-bay o-say ight-bray, I&#x27;ll-way etch-fay our-yay ata-day ay-day and-way ight-nay. Ueries-qay, aphs-gray, and-way ashboards-day oo-tay, I&#x27;ll-way ake-may our-yay ata-day eams-dray ome-cay ue-tray. O-say et&#x27;s-lay ive-day in-way, on&#x27;t-day elay-day, Ouie-lay&#x27;s ere-hay to-way ave</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_LISJ0vRhgOwSJtEykymY</code> | <a href='https://louie.graphistry.com/?dthread=D_LISJ0vRhgOwSJtEykymY' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_rQCYqfb7zn2InVBYWT1b</code> | <a href='https://louie.graphistry.com/?dthread=D_rQCYqfb7zn2InVBYWT1b' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 2 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
@@ -410,10 +410,10 @@
      "height": 903
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:41.309389Z",
-     "iopub.status.busy": "2025-08-04T02:30:41.309245Z",
-     "iopub.status.idle": "2025-08-04T02:30:45.529113Z",
-     "shell.execute_reply": "2025-08-04T02:30:45.528677Z"
+     "iopub.execute_input": "2025-08-04T04:31:46.968116Z",
+     "iopub.status.busy": "2025-08-04T04:31:46.967927Z",
+     "iopub.status.idle": "2025-08-04T04:31:52.173202Z",
+     "shell.execute_reply": "2025-08-04T04:31:52.172753Z"
     },
     "id": "eOHMBwk6cpnz",
     "outputId": "a8deaa5b-20d6-4ed4-e6c9-5a0f9ba5c357"
@@ -422,13 +422,13 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_LISJ0vRhgOwSJtEykymY</code> | Time: 4.2s</div><div style='margin-top: 10px;'><div id='B_7kzKPQfC'><div style='color: #0066cc; font-family: monospace; font-size: 0.9em;'>i LouieAgent::runner</div></div><div id='B_foKggIw_'><div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 Input text:::\n",
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_rQCYqfb7zn2InVBYWT1b</code> | Time: 5.2s</div><div style='margin-top: 10px;'><div id='B_H904upCt'><div style='color: #0066cc; font-family: monospace; font-size: 0.9em;'>i LouieAgent::runner</div></div><div id='B_vNDrzuS3'><div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 Input text:::\n",
        "\n",
        "back to normal, but now with traces!\n",
        "\n",
-       "</div></div><div id='B__DIxWKAN'><div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 Reading chat history. (is_prepared: True)</div></div><div id='B_dJCc_knF'><div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 LouieAgent predict with tools: ['GraphAgent', 'CodeAgent', 'TableAIAgent', 'FirecrawlAgent', 'NotebookAgent', 'DatabricksAgent', 'MermaidAgent', 'PerspectiveAgent', 'KeplerAgent', 'SpannerAgent', 'SpannerPassthroughAgent', 'KustoAgent', 'KustoPassthroughAgent', 'Done', 'Chat'] has_recipes: True has_examples: True</div></div><div id='B_aHqyBpNT'>🎶 Woof woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, with Louie the data dog, we'll save the day! 🎶<br><br>*traces of paw prints in the data sand, leaving a</div><div id='B_kIxzq0SD'><div style='color: #0066cc; font-family: monospace; font-size: 0.9em;'>i Louie output text: 🎶 Woof woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, with Louie the data dog, we'll save the day! 🎶\n",
+       "</div></div><div id='B_s0CyDfQJ'><div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 Reading chat history. (is_prepared: True)</div></div><div id='B_XJDxx3I6'><div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 LouieAgent predict with tools: ['GraphAgent', 'CodeAgent', 'TableAIAgent', 'FirecrawlAgent', 'NotebookAgent', 'DatabricksAgent', 'MermaidAgent', 'PerspectiveAgent', 'KeplerAgent', 'SpannerAgent', 'SpannerPassthroughAgent', 'KustoAgent', 'KustoPassthroughAgent', 'Done', 'Chat'] has_recipes: True has_examples: True</div></div><div id='B_3jsedA93'>🎶 Woof, woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, Louie's here to save the day! 🎶<br><br>*trace* As I chase down data problems, I leave a trail of insights and solutions, ensuring no data stone is left unturned. *trace* With every query and visualization, I map out the path to clarity and understanding. *trace* Together, we'll navigate the data landscape,</div><div id='B_Exd8QnQU'><div style='color: #0066cc; font-family: monospace; font-size: 0.9em;'>i Louie output text: 🎶 Woof, woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, Louie's here to save the day! 🎶\n",
        "\n",
-       "*traces of paw prints in the data sand, leaving a trail of insights so grand!*</div></div></div></div>"
+       "*trace* As I chase down data problems, I leave a trail of insights and solutions, ensuring no data stone is left unturned. *trace* With every query and visualization, I map out the path to clarity and understanding. *trace* Together, we'll navigate the data landscape, turning challenges into triumphs! *trace*</div></div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -450,12 +450,12 @@
        "</div>\n",
        "<div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 Reading chat history. (is_prepared: True)</div>\n",
        "<div style='color: #666; font-family: monospace; font-size: 0.9em;'>🐛 LouieAgent predict with tools: ['GraphAgent', 'CodeAgent', 'TableAIAgent', 'FirecrawlAgent', 'NotebookAgent', 'DatabricksAgent', 'MermaidAgent', 'PerspectiveAgent', 'KeplerAgent', 'SpannerAgent', 'SpannerPassthroughAgent', 'KustoAgent', 'KustoPassthroughAgent', 'Done', 'Chat'] has_recipes: True has_examples: True</div>\n",
-       "<div>🎶 Woof woof, I&#x27;m Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I&#x27;ll fetch your data day and night. Queries, graphs, and dashboards too, I&#x27;ll make your data dreams come true. So let&#x27;s dive in, don&#x27;t delay, with Louie the data dog, we&#x27;ll save the day! 🎶</p><p>*traces of paw prints in the data sand, leaving a</div>\n",
-       "<div style='color: #0066cc; font-family: monospace; font-size: 0.9em;'>i Louie output text: 🎶 Woof woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, with Louie the data dog, we'll save the day! 🎶\n",
+       "<div>🎶 Woof, woof, I&#x27;m Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I&#x27;ll fetch your data day and night. Queries, graphs, and dashboards too, I&#x27;ll make your data dreams come true. So let&#x27;s dive in, don&#x27;t delay, Louie&#x27;s here to save the day! 🎶</p><p>*trace* As I chase down data problems, I leave a trail of insights and solutions, ensuring no data stone is left unturned. *trace* With every query and visualization, I map out the path to clarity and understanding. *trace* Together, we&#x27;ll navigate the data landscape,</div>\n",
+       "<div style='color: #0066cc; font-family: monospace; font-size: 0.9em;'>i Louie output text: 🎶 Woof, woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, Louie's here to save the day! 🎶\n",
        "\n",
-       "*traces of paw prints in the data sand, leaving a trail of insights so grand!*</div>\n",
+       "*trace* As I chase down data problems, I leave a trail of insights and solutions, ensuring no data stone is left unturned. *trace* With every query and visualization, I map out the path to clarity and understanding. *trace* Together, we'll navigate the data landscape, turning challenges into triumphs! *trace*</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_LISJ0vRhgOwSJtEykymY</code> | <a href='https://louie.graphistry.com/?dthread=D_LISJ0vRhgOwSJtEykymY' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_rQCYqfb7zn2InVBYWT1b</code> | <a href='https://louie.graphistry.com/?dthread=D_rQCYqfb7zn2InVBYWT1b' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 3 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
@@ -544,10 +544,10 @@
      "height": 36
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:45.530953Z",
-     "iopub.status.busy": "2025-08-04T02:30:45.530764Z",
-     "iopub.status.idle": "2025-08-04T02:30:45.533657Z",
-     "shell.execute_reply": "2025-08-04T02:30:45.533312Z"
+     "iopub.execute_input": "2025-08-04T04:31:52.174873Z",
+     "iopub.status.busy": "2025-08-04T04:31:52.174678Z",
+     "iopub.status.idle": "2025-08-04T04:31:52.177790Z",
+     "shell.execute_reply": "2025-08-04T04:31:52.177388Z"
     },
     "id": "0ubEy5ElgsN8",
     "outputId": "8887ac1b-e4fe-45aa-b612-7bbba3680629"
@@ -556,7 +556,7 @@
     {
      "data": {
       "text/plain": [
-       "'D_LISJ0vRhgOwSJtEykymY'"
+       "'D_rQCYqfb7zn2InVBYWT1b'"
       ]
      },
      "execution_count": 7,
@@ -577,10 +577,10 @@
      "height": 216
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:45.534993Z",
-     "iopub.status.busy": "2025-08-04T02:30:45.534857Z",
-     "iopub.status.idle": "2025-08-04T02:30:53.906402Z",
-     "shell.execute_reply": "2025-08-04T02:30:53.905966Z"
+     "iopub.execute_input": "2025-08-04T04:31:52.179338Z",
+     "iopub.status.busy": "2025-08-04T04:31:52.179136Z",
+     "iopub.status.idle": "2025-08-04T04:32:00.365165Z",
+     "shell.execute_reply": "2025-08-04T04:32:00.364612Z"
     },
     "id": "y8Ky3IUdguEu",
     "outputId": "a09581b9-0a17-4ade-b1af-9bb63b5a884f"
@@ -589,7 +589,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_RBSUJuCd_qPnyz_zr_je</code> | Time: 4.1s</div><div style='margin-top: 10px;'><div id='B_ge38jzNd'>🎶 I'm Louie, the data hound, in a cyberpunk town, chasing data trails, never backing down. With a nose for queries and a bark for code, I'll fetch insights, lighten your load. From graphs to dashboards, I'll make them shine, turning data chaos into a design. So let's embark on this data quest, with a</div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_FUvLplF6qCLsaNWIlj9Q</code> | Time: 3.9s</div><div style='margin-top: 10px;'><div id='B_ygESBqVY'>🎶 I'm Louie, the data hound, in the cyberpunk scene, I roam around. With a nose for data and a heart so true, I'll fetch the insights just for you. From queries to graphs, I'll make them shine, turning data into gold, one byte at a time. So let's dive deep, explore the unknown, in this digital world,</div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -601,7 +601,7 @@
     {
      "data": {
       "text/plain": [
-       "'D_RBSUJuCd_qPnyz_zr_je'"
+       "'D_FUvLplF6qCLsaNWIlj9Q'"
       ]
      },
      "execution_count": 8,
@@ -631,10 +631,10 @@
      "height": 88
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:53.908087Z",
-     "iopub.status.busy": "2025-08-04T02:30:53.907977Z",
-     "iopub.status.idle": "2025-08-04T02:30:53.909985Z",
-     "shell.execute_reply": "2025-08-04T02:30:53.909727Z"
+     "iopub.execute_input": "2025-08-04T04:32:00.367041Z",
+     "iopub.status.busy": "2025-08-04T04:32:00.366852Z",
+     "iopub.status.idle": "2025-08-04T04:32:00.369900Z",
+     "shell.execute_reply": "2025-08-04T04:32:00.369489Z"
     },
     "id": "9WV3CAxDnFgB",
     "outputId": "014ea410-75da-4cec-e9aa-2e1906f10eb0"
@@ -643,7 +643,7 @@
     {
      "data": {
       "text/plain": [
-       "\"🎶 I'm Louie, the data hound, in a cyberpunk town, chasing data trails, never backing down. With a nose for queries and a bark for code, I'll fetch insights, lighten your load. From graphs to dashboards, I'll make them shine, turning data chaos into a design. So let's embark on this data quest, with a\""
+       "\"🎶 I'm Louie, the data hound, in the cyberpunk scene, I roam around. With a nose for data and a heart so true, I'll fetch the insights just for you. From queries to graphs, I'll make them shine, turning data into gold, one byte at a time. So let's dive deep, explore the unknown, in this digital world,\""
       ]
      },
      "execution_count": 9,
@@ -665,10 +665,10 @@
      "height": 70
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:53.911253Z",
-     "iopub.status.busy": "2025-08-04T02:30:53.911140Z",
-     "iopub.status.idle": "2025-08-04T02:30:53.913203Z",
-     "shell.execute_reply": "2025-08-04T02:30:53.912948Z"
+     "iopub.execute_input": "2025-08-04T04:32:00.371276Z",
+     "iopub.status.busy": "2025-08-04T04:32:00.371135Z",
+     "iopub.status.idle": "2025-08-04T04:32:00.373718Z",
+     "shell.execute_reply": "2025-08-04T04:32:00.373381Z"
     },
     "id": "d4Hu4BsWnZTl",
     "outputId": "038841c3-c353-4db4-c808-e5cc0696a4c7"
@@ -677,7 +677,7 @@
     {
      "data": {
       "text/plain": [
-       "\"🎶 Woof, woof, I'm Louie, the data dog, chasing bytes and bits, never lost in the fog. With a wag of my tail and a bark so bright, I'll fetch your data, day or night. From queries to graphs, I'll make it clear, turning data puzzles into cheer. So let's dive in, with a joyful bark, solving\""
+       "\"🎶 Woof, woof, I'm Louie, the data dog, chasing bytes and bits through the cyber fog. With a wag of my tail and a bark so bright, I'll fetch your data, day or night. Queries and graphs, I'll make them dance, turning data into insights at every chance. So let's solve puzzles, you and me, in this digital world\""
       ]
      },
      "execution_count": 10,
@@ -699,10 +699,10 @@
      "height": 122
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:53.914368Z",
-     "iopub.status.busy": "2025-08-04T02:30:53.914263Z",
-     "iopub.status.idle": "2025-08-04T02:30:53.916300Z",
-     "shell.execute_reply": "2025-08-04T02:30:53.916073Z"
+     "iopub.execute_input": "2025-08-04T04:32:00.375133Z",
+     "iopub.status.busy": "2025-08-04T04:32:00.374994Z",
+     "iopub.status.idle": "2025-08-04T04:32:00.377543Z",
+     "shell.execute_reply": "2025-08-04T04:32:00.377203Z"
     },
     "id": "9GM60VPvkt3Y",
     "outputId": "214b168f-1a56-473c-f7f4-b42cacf56e53"
@@ -711,7 +711,7 @@
     {
      "data": {
       "text/plain": [
-       "\"🎶 Woof woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, with Louie the data dog, we'll save the day! 🎶\\n\\n*traces of paw prints in the data sand, leaving a\""
+       "\"🎶 Woof, woof, I'm Louie, the data dog, chasing data through the fog. With a wag of my tail and a bark so bright, I'll fetch your data day and night. Queries, graphs, and dashboards too, I'll make your data dreams come true. So let's dive in, don't delay, Louie's here to save the day! 🎶\\n\\n*trace* As I chase down data problems, I leave a trail of insights and solutions, ensuring no data stone is left unturned. *trace* With every query and visualization, I map out the path to clarity and understanding. *trace* Together, we'll navigate the data landscape,\""
       ]
      },
      "execution_count": 11,
@@ -753,10 +753,10 @@
      "height": 1000
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:53.917520Z",
-     "iopub.status.busy": "2025-08-04T02:30:53.917420Z",
-     "iopub.status.idle": "2025-08-04T02:30:56.917743Z",
-     "shell.execute_reply": "2025-08-04T02:30:56.917452Z"
+     "iopub.execute_input": "2025-08-04T04:32:00.378924Z",
+     "iopub.status.busy": "2025-08-04T04:32:00.378786Z",
+     "iopub.status.idle": "2025-08-04T04:32:04.166879Z",
+     "shell.execute_reply": "2025-08-04T04:32:04.166405Z"
     },
     "id": "oduG16oZpE6P",
     "outputId": "2eedd7c2-3c4c-4ba1-a6b4-26b61af9a3b6"
@@ -765,7 +765,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_RBSUJuCd_qPnyz_zr_je</code> | Time: 2.2s</div><div style='margin-top: 10px;'><div id='B_T8kxjoiP'>fetching data</div><div id='B_yi3qXtKj'>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook`<br>    LIMIT 10</div><div id='B_I52HplM1'><div style='background: #f0f0f0; padding: 5px; margin: 5px 0;'>📊 DataFrame: B_I52HplM1 (shape: 10 x 25)</div></div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_FUvLplF6qCLsaNWIlj9Q</code> | Time: 2.9s</div><div style='margin-top: 10px;'><div id='B_Y6Yz0hYj'>fetching data</div><div id='B_WV8ZejC3'>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook`<br>    LIMIT 10</div><div id='B_kEJv1cDD'><div style='background: #f0f0f0; padding: 5px; margin: 5px 0;'>📊 DataFrame: B_kEJv1cDD (shape: 10 x 25)</div></div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1068,7 +1068,7 @@
        "<p>10 rows × 25 columns</p>\n",
        "</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_RBSUJuCd_qPnyz_zr_je</code> | <a href='https://louie.graphistry.com/?dthread=D_RBSUJuCd_qPnyz_zr_je' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_FUvLplF6qCLsaNWIlj9Q</code> | <a href='https://louie.graphistry.com/?dthread=D_FUvLplF6qCLsaNWIlj9Q' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 3 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
@@ -1142,10 +1142,10 @@
      "height": 383
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:56.919139Z",
-     "iopub.status.busy": "2025-08-04T02:30:56.919024Z",
-     "iopub.status.idle": "2025-08-04T02:30:56.930047Z",
-     "shell.execute_reply": "2025-08-04T02:30:56.929806Z"
+     "iopub.execute_input": "2025-08-04T04:32:04.168282Z",
+     "iopub.status.busy": "2025-08-04T04:32:04.168190Z",
+     "iopub.status.idle": "2025-08-04T04:32:04.176551Z",
+     "shell.execute_reply": "2025-08-04T04:32:04.176166Z"
     },
     "id": "EnvROqbNp0lx",
     "outputId": "11978bac-bcce-48db-ac39-0599a9c7a95c"
@@ -1197,28 +1197,52 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>65.52.243.21</td>\n",
-       "      <td>fb617e9e-c0c7-6000-32f0-2e462ff7bbde</td>\n",
-       "      <td>2018-08-20T13:05:48</td>\n",
+       "      <th>0</th>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-d0dd-6000-daf9-da44fcd45d4e</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
        "      <td>SharePoint</td>\n",
-       "      <td>4b143e6d-91b0-4b07-7253-08d5f28d37c3</td>\n",
-       "      <td>None</td>\n",
-       "      <td>List</td>\n",
+       "      <td>8a1fd9ad-95d3-4bea-a806-08d5f28ec619</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
        "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
-       "      <td>None</td>\n",
-       "      <td>https://frothly-my.sharepoint.com/personal/pce...</td>\n",
+       "      <td>37ab8c26-f775-4a03-97b3-074c81a00f33</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
        "      <td>...</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>ODMTADocCache/1.0</td>\n",
-       "      <td>app@sharepoint</td>\n",
-       "      <td>i:0i.t|00000003-0000-0ff1-ce00-000000000000|ap...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>beverages-02-00034-v2.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
        "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>40.97.148.181</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
+       "      <td>2018-08-20T13:16:54</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>0ad166f0-5312-4e35-e017-08d5f28ec4fb</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Web</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
+       "      <td>...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Substrate Search 1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>SharePoint</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1244,70 +1268,51 @@
        "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
        "      <td>OneDrive</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>104.238.59.42</td>\n",
-       "      <td>f9617e9e-f0de-6000-32f0-299be8e0a683</td>\n",
-       "      <td>2018-08-20T13:05:40</td>\n",
-       "      <td>SharePoint</td>\n",
-       "      <td>a1cac3e4-3102-4e0c-d258-08d5f28d3331</td>\n",
-       "      <td>No</td>\n",
-       "      <td>File</td>\n",
-       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
-       "      <td>d2c4bb13-c97e-4707-9e9b-53dc0e2513b5</td>\n",
-       "      <td>https://frothly-my.sharepoint.com/personal/pce...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>pptx</td>\n",
-       "      <td>Beer styles.pptx</td>\n",
-       "      <td>Documents</td>\n",
-       "      <td>Microsoft Office PowerPoint 2014</td>\n",
-       "      <td>pcerf@froth.ly</td>\n",
-       "      <td>i:0h.f|membership|1003bffdac730049@live.com</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
-       "      <td>OneDrive</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "<p>3 rows × 25 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "        ClientIP                         CorrelationId         CreationTime  \\\n",
-       "5   65.52.243.21  fb617e9e-c0c7-6000-32f0-2e462ff7bbde  2018-08-20T13:05:48   \n",
-       "4  104.238.59.42  0a627e9e-f0d0-6000-daf9-dc8f468313e3  2018-08-20T13:06:50   \n",
-       "6  104.238.59.42  f9617e9e-f0de-6000-32f0-299be8e0a683  2018-08-20T13:05:40   \n",
+       "         ClientIP                         CorrelationId         CreationTime  \\\n",
+       "0  107.77.213.173  9e627e9e-d0dd-6000-daf9-da44fcd45d4e  2018-08-20T13:16:56   \n",
+       "3   40.97.148.181  fa2fd17c-daf8-4062-8f87-d411eb537314  2018-08-20T13:16:54   \n",
+       "4   104.238.59.42  0a627e9e-f0d0-6000-daf9-dc8f468313e3  2018-08-20T13:06:50   \n",
        "\n",
        "  EventSource                                    Id ImplicitShare ItemType  \\\n",
-       "5  SharePoint  4b143e6d-91b0-4b07-7253-08d5f28d37c3          None     List   \n",
+       "0  SharePoint  8a1fd9ad-95d3-4bea-a806-08d5f28ec619            No     File   \n",
+       "3  SharePoint  0ad166f0-5312-4e35-e017-08d5f28ec4fb          None      Web   \n",
        "4  SharePoint  9b5ad97e-f03f-4648-a536-08d5f28d5cad          None     File   \n",
-       "6  SharePoint  a1cac3e4-3102-4e0c-d258-08d5f28d3331            No     File   \n",
        "\n",
        "                                 ListId                      ListItemUniqueId  \\\n",
-       "5  67091393-e290-421e-ac6a-2734e2b12a94                                  None   \n",
+       "0  67091393-e290-421e-ac6a-2734e2b12a94  37ab8c26-f775-4a03-97b3-074c81a00f33   \n",
+       "3                                  None                                  None   \n",
        "4  67091393-e290-421e-ac6a-2734e2b12a94  d2c4bb13-c97e-4707-9e9b-53dc0e2513b5   \n",
-       "6  67091393-e290-421e-ac6a-2734e2b12a94  d2c4bb13-c97e-4707-9e9b-53dc0e2513b5   \n",
        "\n",
        "                                            ObjectId  ... SourceFileExtension  \\\n",
-       "5  https://frothly-my.sharepoint.com/personal/pce...  ...                None   \n",
+       "0  https://frothly-my.sharepoint.com/personal/fyo...  ...                 pdf   \n",
+       "3               fa2fd17c-daf8-4062-8f87-d411eb537314  ...                None   \n",
        "4  https://frothly-my.sharepoint.com/personal/pce...  ...                pptx   \n",
-       "6  https://frothly-my.sharepoint.com/personal/pce...  ...                pptx   \n",
        "\n",
-       "     SourceFileName  SourceRelativeUrl                         UserAgent  \\\n",
-       "5              None               None                 ODMTADocCache/1.0   \n",
-       "4  Beer styles.pptx          Documents  Microsoft Office PowerPoint 2014   \n",
-       "6  Beer styles.pptx          Documents  Microsoft Office PowerPoint 2014   \n",
+       "              SourceFileName  SourceRelativeUrl  \\\n",
+       "0  beverages-02-00034-v2.pdf          Documents   \n",
+       "3                       None               None   \n",
+       "4           Beer styles.pptx          Documents   \n",
        "\n",
-       "           UserId                                            UserKey UserType  \\\n",
-       "5  app@sharepoint  i:0i.t|00000003-0000-0ff1-ce00-000000000000|ap...        0   \n",
-       "4  pcerf@froth.ly        i:0h.f|membership|1003bffdac730049@live.com        0   \n",
-       "6  pcerf@froth.ly        i:0h.f|membership|1003bffdac730049@live.com        0   \n",
+       "                          UserAgent           UserId  \\\n",
+       "0                   OneDriveMpc/1.0  fyodor@froth.ly   \n",
+       "3              Substrate Search 1.0  fyodor@froth.ly   \n",
+       "4  Microsoft Office PowerPoint 2014   pcerf@froth.ly   \n",
        "\n",
-       "  Version                                 WebId  Workload  \n",
-       "5       1  7acb35b6-e1ec-44ed-9099-38580e330ed0  OneDrive  \n",
-       "4       1  7acb35b6-e1ec-44ed-9099-38580e330ed0  OneDrive  \n",
-       "6       1  7acb35b6-e1ec-44ed-9099-38580e330ed0  OneDrive  \n",
+       "                                       UserKey UserType Version  \\\n",
+       "0  i:0h.f|membership|1003bffda2e71ff9@live.com        0       1   \n",
+       "3  i:0h.f|membership|1003bffda2e71ff9@live.com        0       1   \n",
+       "4  i:0h.f|membership|1003bffdac730049@live.com        0       1   \n",
+       "\n",
+       "                                  WebId    Workload  \n",
+       "0  7acb35b6-e1ec-44ed-9099-38580e330ed0    OneDrive  \n",
+       "3                                  None  SharePoint  \n",
+       "4  7acb35b6-e1ec-44ed-9099-38580e330ed0    OneDrive  \n",
        "\n",
        "[3 rows x 25 columns]"
       ]
@@ -1331,10 +1336,10 @@
      "height": 933
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:56.931183Z",
-     "iopub.status.busy": "2025-08-04T02:30:56.931070Z",
-     "iopub.status.idle": "2025-08-04T02:30:56.938812Z",
-     "shell.execute_reply": "2025-08-04T02:30:56.938475Z"
+     "iopub.execute_input": "2025-08-04T04:32:04.177941Z",
+     "iopub.status.busy": "2025-08-04T04:32:04.177800Z",
+     "iopub.status.idle": "2025-08-04T04:32:04.188733Z",
+     "shell.execute_reply": "2025-08-04T04:32:04.188414Z"
     },
     "id": "f9QKJM2LSTII",
     "outputId": "5a2fdb4b-1dd1-4f51-b090-02094307a9f2"
@@ -1759,10 +1764,10 @@
      "height": 468
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:30:56.940216Z",
-     "iopub.status.busy": "2025-08-04T02:30:56.940087Z",
-     "iopub.status.idle": "2025-08-04T02:31:04.348806Z",
-     "shell.execute_reply": "2025-08-04T02:31:04.348331Z"
+     "iopub.execute_input": "2025-08-04T04:32:04.189955Z",
+     "iopub.status.busy": "2025-08-04T04:32:04.189869Z",
+     "iopub.status.idle": "2025-08-04T04:32:12.074947Z",
+     "shell.execute_reply": "2025-08-04T04:32:12.074592Z"
     },
     "id": "vKq6tVF5qBRw",
     "outputId": "5b2605eb-8485-45f5-dd4f-db9b7bb0f057"
@@ -1771,7 +1776,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_RBSUJuCd_qPnyz_zr_je</code> | Time: 7.4s</div><div style='margin-top: 10px;'><div id='B_YObNKTp9'>It seems there was an attempt to retrieve 4 events from the 'o365-management-activity' table, but the query failed because the table or view could not be found. This error suggests that there might be an issue with the table's name, schema, or catalog. To resolve this, you should verify the spelling and correctness of the table name, ensure that the schema and catalog are correctly specified, and check the current schema settings. If the table or view does not exist, you may need to create it or adjust your query to target an existing table.</div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_FUvLplF6qCLsaNWIlj9Q</code> | Time: 7.0s</div><div style='margin-top: 10px;'><div id='B_PvHfrIGL'>The query successfully retrieved 4 events from the 'o365_management_activity_flat_tcook' table. The data includes various details such as 'ClientIP', 'CreationTime', 'EventSource', and 'Operation', among others. All events are related to SharePoint activities, with three events involving file previews and one involving a search query. The user 'fyodor@froth.ly' appears consistently across these events, indicating their activity on the platform. The data provides insights into user interactions with SharePoint, specifically focusing on document access and search activities.</div><div id='B_s82lMld8'>fetching data</div><div id='B_YYg57DF4'>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook` LIMIT 4</div><div id='B_lk6JiNiM'><div style='background: #f0f0f0; padding: 5px; margin: 5px 0;'>📊 DataFrame: B_lk6JiNiM (shape: 4 x 25)</div></div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1785,15 +1790,160 @@
       "text/html": [
        "<div style='border: 1px solid #ddd; padding: 10px; border-radius: 5px; margin-bottom: 10px;'>\n",
        "<h4 style='margin-top: 0;'>🤖 LouieAI Response</h4>\n",
-       "<div>It seems there was an attempt to retrieve 4 events from the &#x27;o365-management-activity&#x27; table, but the query failed because the table or view could not be found. This error suggests that there might be an issue with the table&#x27;s name, schema, or catalog. To resolve this, you should verify the spelling and correctness of the table name, ensure that the schema and catalog are correctly specified, and check the current schema settings. If the table or view does not exist, you may need to create it or adjust your query to target an existing table.</div>\n",
+       "<div>The query successfully retrieved 4 events from the &#x27;o365_management_activity_flat_tcook&#x27; table. The data includes various details such as &#x27;ClientIP&#x27;, &#x27;CreationTime&#x27;, &#x27;EventSource&#x27;, and &#x27;Operation&#x27;, among others. All events are related to SharePoint activities, with three events involving file previews and one involving a search query. The user &#x27;fyodor@froth.ly&#x27; appears consistently across these events, indicating their activity on the platform. The data provides insights into user interactions with SharePoint, specifically focusing on document access and search activities.</div>\n",
+       "<div>fetching data</div>\n",
+       "<div>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook` LIMIT 4</div>\n",
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ClientIP</th>\n",
+       "      <th>CorrelationId</th>\n",
+       "      <th>CreationTime</th>\n",
+       "      <th>EventSource</th>\n",
+       "      <th>Id</th>\n",
+       "      <th>ImplicitShare</th>\n",
+       "      <th>ItemType</th>\n",
+       "      <th>ListId</th>\n",
+       "      <th>ListItemUniqueId</th>\n",
+       "      <th>ObjectId</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SourceFileExtension</th>\n",
+       "      <th>SourceFileName</th>\n",
+       "      <th>SourceRelativeUrl</th>\n",
+       "      <th>UserAgent</th>\n",
+       "      <th>UserId</th>\n",
+       "      <th>UserKey</th>\n",
+       "      <th>UserType</th>\n",
+       "      <th>Version</th>\n",
+       "      <th>WebId</th>\n",
+       "      <th>Workload</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-d0dd-6000-daf9-da44fcd45d4e</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>8a1fd9ad-95d3-4bea-a806-08d5f28ec619</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>37ab8c26-f775-4a03-97b3-074c81a00f33</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>beverages-02-00034-v2.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-60d3-6000-32f0-2235e1b3a20b</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>7d1dd9e0-63b3-4277-7a03-08d5f28ec5e3</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>bb017930-2bf5-4953-b38a-716ba3217703</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>craftbeerdotcom-beer-styles.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-a0db-6000-daf9-da5a21ed5a92</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>f5ad6c89-25b3-420c-f889-08d5f28ec656</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>456e3291-27ad-455e-9cb7-a01722ffa0fa</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>fundamental of beer and hop chemistry.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>40.97.148.181</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
+       "      <td>2018-08-20T13:16:54</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>0ad166f0-5312-4e35-e017-08d5f28ec4fb</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Web</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
+       "      <td>...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Substrate Search 1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>SharePoint</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4 rows × 25 columns</p>\n",
+       "</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_RBSUJuCd_qPnyz_zr_je</code> | <a href='https://louie.graphistry.com/?dthread=D_RBSUJuCd_qPnyz_zr_je' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_FUvLplF6qCLsaNWIlj9Q</code> | <a href='https://louie.graphistry.com/?dthread=D_FUvLplF6qCLsaNWIlj9Q' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 4 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
        "<p><b>Latest Response:</b></p>\n",
        "<ul style='margin: 5px 0;'>\n",
-       "<li>1 text element(s) - access with <code>lui.text</code> or <code>lui.texts</code></li>\n",
+       "<li>3 text element(s) - access with <code>lui.text</code> or <code>lui.texts</code></li>\n",
+       "<li>1 dataframe(s) - access with <code>lui.df</code> or <code>lui.dfs</code></li>\n",
        "</ul>\n",
        "<details><summary><b>Quick Help</b> (click to expand)</summary>\n",
        "<pre style='margin: 10px 0; padding: 10px; background: #f5f5f5;'>\n",
@@ -1835,7 +1985,7 @@
        "</div>"
       ],
       "text/plain": [
-       "<LouieAI Notebook Interface | Session: Active | History: 4 responses | Traces: Disabled | Latest: 1 text>"
+       "<LouieAI Notebook Interface | Session: Active | History: 4 responses | Traces: Disabled | Latest: 3 text, 1 dataframe>"
       ]
      },
      "execution_count": 15,
@@ -1844,7 +1994,7 @@
     }
    ],
    "source": [
-    "lui(\"get 4 events from o365-management-activity\", agent=\"DatabricksAgent\")"
+    "lui(\"get 4 events from o365_management_activity_flat_tcook\", agent=\"DatabricksAgent\")"
    ]
   },
   {
@@ -1867,10 +2017,10 @@
      "height": 1000
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:31:04.350632Z",
-     "iopub.status.busy": "2025-08-04T02:31:04.350438Z",
-     "iopub.status.idle": "2025-08-04T02:31:41.740538Z",
-     "shell.execute_reply": "2025-08-04T02:31:41.739952Z"
+     "iopub.execute_input": "2025-08-04T04:32:12.076301Z",
+     "iopub.status.busy": "2025-08-04T04:32:12.076151Z",
+     "iopub.status.idle": "2025-08-04T04:32:23.209687Z",
+     "shell.execute_reply": "2025-08-04T04:32:23.209113Z"
     },
     "id": "y_QRaH21qX6Y",
     "outputId": "fdfa5230-4145-450a-b025-70a4792c8b69"
@@ -1879,7 +2029,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_RBSUJuCd_qPnyz_zr_je</code> | Time: 36.4s</div><div style='margin-top: 10px;'><div id='B_fwkwbQID'>The user wants to retrieve 4 events from the 'o365-management-activity' table in Databricks. Previously, there was an issue with the table not being found. I need to ensure the table name is correct and exists in the Databricks environment.<br><br>Plan:<br>1. Verify the existence of the 'o365-management-activity' table in Databricks.<br>2. If the table exists, retrieve 4 events from it.<br>3. If the table does not exist, inform the user and suggest checking the table name or creating it if necessary.<br><br>DatabricksAgent<br>show all tablesThe 'o365-management-activity' table does exist in the Databricks environment under the schema `client_demos`.`botsv3`. Now, I will proceed to retrieve 4 events from this table.<br><br>DatabricksAgent<br>get 4 events from `client_demos`.`botsv3`.`o365-management-activity`It seems there is a persistent issue with retrieving data from the 'o365-management-activity' table in Databricks, even though the table exists under the schema `client_demos`.`botsv3`. The error indicates that the table or view cannot be found, which suggests a potential problem with the schema or catalog settings, or possibly a permissions issue.<br><br>Here's what you can do to resolve this:<br><br>1. **Double-check the Schema and Catalog**: Ensure that the schema and catalog are correctly specified in your query. You might want to use the fully qualified table name.<br><br>2. **Verify Permissions**: Make sure you have the necessary permissions to access the table. If you don't, you may need to contact your database administrator.<br><br>3. **Check Current Schema Settings**: Verify the current schema settings to ensure they are correct.<br><br>4. **Consult with a Database Administrator**: If the problem persists, it might be helpful to consult with your database administrator for further assistance.<br><br>If you need further help, feel free to</div><div id='B_wCjAA1vX'><div style='color: gray;'>[CallElement] show all tables</div></div><div id='B___gpi8LM'>It seems that the previous attempt to retrieve events from the 'o365-management-activity' table failed because the table or view could not be found. This issue likely stemmed from an incorrect table name, schema, or catalog specification. Upon listing all tables in the Databricks database, it was confirmed that the 'o365-management-activity' table does exist under the schema `client_demos`.`botsv3`. To resolve the initial query error, ensure that the table name is correctly specified in the query, including the correct schema and catalog. If the issue persists, double-check the current schema settings or consider using the fully qualified table name in your query.</div><div id='B_MClt3shG'>listing tables</div><div id='B_eXp9F0io'><div style='background: #f0f0f0; padding: 5px; margin: 5px 0;'>📊 DataFrame: B_eXp9F0io (shape: 287 x 1)</div></div><div id='B_uOql6myp'><div style='color: gray;'>[CallElement] get 4 events from `client_demos`.`botsv3`.`o365-management-activity`</div></div><div id='B_Nmf8ivNf'>It seems there is a persistent issue with retrieving data from the 'client_demos.botsv3.o365-management-activity' table. Despite confirming the table's existence in the database, attempts to fetch data continue to result in an error indicating that the table or view cannot be found. This suggests a potential problem with the schema or catalog settings, or possibly a permissions issue. To resolve this, double-check the schema and catalog specifications in your query, ensure you have the necessary permissions to access the table, and verify the current schema settings. If the problem persists, consider consulting with your database administrator for further assistance.</div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_FUvLplF6qCLsaNWIlj9Q</code> | Time: 10.2s</div><div style='margin-top: 10px;'><div id='B_ACDnurmE'>The user wants to retrieve 4 events from the 'o365_management_activity_flat_tcook' table in Databricks. I will use the DatabricksAgent to perform this query.<br><br>DatabricksAgent<br>Get 4 events from the o365_management_activity_flat_tcook table.The query successfully retrieved 4 events from the 'o365_management_activity_flat_tcook' table in Databricks. The data includes various details such as 'ClientIP', 'CreationTime', 'EventSource', and 'Operation', among others. All events are related to SharePoint activities, with three events involving file previews and one involving a search query. The user 'fyodor@froth.ly' appears consistently across these events, indicating their activity on the platform. The data provides insights into user interactions with SharePoint, specifically focusing on document</div><div id='B_bonR41P4'><div style='color: gray;'>[CallElement] Get 4 events from the o365_management_activity_flat_tcook table.</div></div><div id='B_zh7wk2BD'>The query successfully retrieved 4 events from the 'o365_management_activity_flat_tcook' table. The data includes various details such as 'ClientIP', 'CreationTime', 'EventSource', and 'Operation', among others. All events are related to SharePoint activities, with three events involving file previews and one involving a search query. The user 'fyodor@froth.ly' appears consistently across these events, indicating their activity on the platform. The data provides insights into user interactions with SharePoint, specifically focusing on document access and search activities.</div><div id='B_Ka1JqzOV'>fetching data</div><div id='B_2vKH3FbW'>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook` LIMIT 4</div><div id='B_mHIQF2AM'><div style='background: #f0f0f0; padding: 5px; margin: 5px 0;'>📊 DataFrame: B_mHIQF2AM (shape: 4 x 25)</div></div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1893,10 +2043,11 @@
       "text/html": [
        "<div style='border: 1px solid #ddd; padding: 10px; border-radius: 5px; margin-bottom: 10px;'>\n",
        "<h4 style='margin-top: 0;'>🤖 LouieAI Response</h4>\n",
-       "<div>The user wants to retrieve 4 events from the &#x27;o365-management-activity&#x27; table in Databricks. Previously, there was an issue with the table not being found. I need to ensure the table name is correct and exists in the Databricks environment.</p><p>Plan:<br>1. Verify the existence of the &#x27;o365-management-activity&#x27; table in Databricks.<br>2. If the table exists, retrieve 4 events from it.<br>3. If the table does not exist, inform the user and suggest checking the table name or creating it if necessary.</p><p>DatabricksAgent<br>show all tablesThe &#x27;o365-management-activity&#x27; table does exist in the Databricks environment under the schema `client_demos`.`botsv3`. Now, I will proceed to retrieve 4 events from this table.</p><p>DatabricksAgent<br>get 4 events from `client_demos`.`botsv3`.`o365-management-activity`It seems there is a persistent issue with retrieving data from the &#x27;o365-management-activity&#x27; table in Databricks, even though the table exists under the schema `client_demos`.`botsv3`. The error indicates that the table or view cannot be found, which suggests a potential problem with the schema or catalog settings, or possibly a permissions issue.</p><p>Here&#x27;s what you can do to resolve this:</p><p>1. **Double-check the Schema and Catalog**: Ensure that the schema and catalog are correctly specified in your query. You might want to use the fully qualified table name.</p><p>2. **Verify Permissions**: Make sure you have the necessary permissions to access the table. If you don&#x27;t, you may need to contact your database administrator.</p><p>3. **Check Current Schema Settings**: Verify the current schema settings to ensure they are correct.</p><p>4. **Consult with a Database Administrator**: If the problem persists, it might be helpful to consult with your database administrator for further assistance.</p><p>If you need further help, feel free to</div>\n",
-       "<div style='color: gray;'>[CallElement] show all tables</div>\n",
-       "<div>It seems that the previous attempt to retrieve events from the &#x27;o365-management-activity&#x27; table failed because the table or view could not be found. This issue likely stemmed from an incorrect table name, schema, or catalog specification. Upon listing all tables in the Databricks database, it was confirmed that the &#x27;o365-management-activity&#x27; table does exist under the schema `client_demos`.`botsv3`. To resolve the initial query error, ensure that the table name is correctly specified in the query, including the correct schema and catalog. If the issue persists, double-check the current schema settings or consider using the fully qualified table name in your query.</div>\n",
-       "<div>listing tables</div>\n",
+       "<div>The user wants to retrieve 4 events from the &#x27;o365_management_activity_flat_tcook&#x27; table in Databricks. I will use the DatabricksAgent to perform this query.</p><p>DatabricksAgent<br>Get 4 events from the o365_management_activity_flat_tcook table.The query successfully retrieved 4 events from the &#x27;o365_management_activity_flat_tcook&#x27; table in Databricks. The data includes various details such as &#x27;ClientIP&#x27;, &#x27;CreationTime&#x27;, &#x27;EventSource&#x27;, and &#x27;Operation&#x27;, among others. All events are related to SharePoint activities, with three events involving file previews and one involving a search query. The user &#x27;fyodor@froth.ly&#x27; appears consistently across these events, indicating their activity on the platform. The data provides insights into user interactions with SharePoint, specifically focusing on document</div>\n",
+       "<div style='color: gray;'>[CallElement] Get 4 events from the o365_management_activity_flat_tcook table.</div>\n",
+       "<div>The query successfully retrieved 4 events from the &#x27;o365_management_activity_flat_tcook&#x27; table. The data includes various details such as &#x27;ClientIP&#x27;, &#x27;CreationTime&#x27;, &#x27;EventSource&#x27;, and &#x27;Operation&#x27;, among others. All events are related to SharePoint activities, with three events involving file previews and one involving a search query. The user &#x27;fyodor@froth.ly&#x27; appears consistently across these events, indicating their activity on the platform. The data provides insights into user interactions with SharePoint, specifically focusing on document access and search activities.</div>\n",
+       "<div>fetching data</div>\n",
+       "<div>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook` LIMIT 4</div>\n",
        "<div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
@@ -1915,62 +2066,132 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>table_name</th>\n",
+       "      <th>ClientIP</th>\n",
+       "      <th>CorrelationId</th>\n",
+       "      <th>CreationTime</th>\n",
+       "      <th>EventSource</th>\n",
+       "      <th>Id</th>\n",
+       "      <th>ImplicitShare</th>\n",
+       "      <th>ItemType</th>\n",
+       "      <th>ListId</th>\n",
+       "      <th>ListItemUniqueId</th>\n",
+       "      <th>ObjectId</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SourceFileExtension</th>\n",
+       "      <th>SourceFileName</th>\n",
+       "      <th>SourceRelativeUrl</th>\n",
+       "      <th>UserAgent</th>\n",
+       "      <th>UserId</th>\n",
+       "      <th>UserKey</th>\n",
+       "      <th>UserType</th>\n",
+       "      <th>Version</th>\n",
+       "      <th>WebId</th>\n",
+       "      <th>Workload</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>`client_demos`.`botsv3`.`access-combined`</td>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-d0dd-6000-daf9-da44fcd45d4e</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>8a1fd9ad-95d3-4bea-a806-08d5f28ec619</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>37ab8c26-f775-4a03-97b3-074c81a00f33</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>beverages-02-00034-v2.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>`client_demos`.`botsv3`.`access_combined`</td>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-60d3-6000-32f0-2235e1b3a20b</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>7d1dd9e0-63b3-4277-7a03-08d5f28ec5e3</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>bb017930-2bf5-4953-b38a-716ba3217703</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>craftbeerdotcom-beer-styles.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>`client_demos`.`botsv3`.`alternatives`</td>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-a0db-6000-daf9-da5a21ed5a92</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>f5ad6c89-25b3-420c-f889-08d5f28ec656</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>456e3291-27ad-455e-9cb7-a01722ffa0fa</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>fundamental of beer and hop chemistry.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>`client_demos`.`botsv3`.`amazon-ssm-agent`</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>`client_demos`.`botsv3`.`amazon-ssm-agent-too-...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
+       "      <td>40.97.148.181</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
+       "      <td>2018-08-20T13:16:54</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>0ad166f0-5312-4e35-e017-08d5f28ec4fb</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Web</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
        "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>282</th>\n",
-       "      <td>`system`.`information_schema`.`tables`</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>283</th>\n",
-       "      <td>`system`.`information_schema`.`views`</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>284</th>\n",
-       "      <td>`system`.`information_schema`.`volume_privileges`</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>285</th>\n",
-       "      <td>`system`.`information_schema`.`volume_tags`</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>286</th>\n",
-       "      <td>`system`.`information_schema`.`volumes`</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Substrate Search 1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>SharePoint</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>287 rows × 1 columns</p>\n",
+       "<p>4 rows × 25 columns</p>\n",
        "</div>\n",
-       "<div style='color: gray;'>[CallElement] get 4 events from `client_demos`.`botsv3`.`o365-management-activity`</div>\n",
-       "<div>It seems there is a persistent issue with retrieving data from the &#x27;client_demos.botsv3.o365-management-activity&#x27; table. Despite confirming the table&#x27;s existence in the database, attempts to fetch data continue to result in an error indicating that the table or view cannot be found. This suggests a potential problem with the schema or catalog settings, or possibly a permissions issue. To resolve this, double-check the schema and catalog specifications in your query, ensure you have the necessary permissions to access the table, and verify the current schema settings. If the problem persists, consider consulting with your database administrator for further assistance.</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_RBSUJuCd_qPnyz_zr_je</code> | <a href='https://louie.graphistry.com/?dthread=D_RBSUJuCd_qPnyz_zr_je' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_FUvLplF6qCLsaNWIlj9Q</code> | <a href='https://louie.graphistry.com/?dthread=D_FUvLplF6qCLsaNWIlj9Q' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 5 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
@@ -2028,7 +2249,7 @@
     }
    ],
    "source": [
-    "lui(\"\"\"get 4 events from databrick's o365-management-activity\"\"\")"
+    "lui(\"\"\"get 4 events from databrick's o365_management_activity_flat_tcook\"\"\")"
    ]
   },
   {
@@ -2049,10 +2270,10 @@
      "height": 1000
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:31:41.742431Z",
-     "iopub.status.busy": "2025-08-04T02:31:41.742242Z",
-     "iopub.status.idle": "2025-08-04T02:32:09.411961Z",
-     "shell.execute_reply": "2025-08-04T02:32:09.411501Z"
+     "iopub.execute_input": "2025-08-04T04:32:23.210978Z",
+     "iopub.status.busy": "2025-08-04T04:32:23.210875Z",
+     "iopub.status.idle": "2025-08-04T04:33:01.921892Z",
+     "shell.execute_reply": "2025-08-04T04:33:01.921499Z"
     },
     "id": "5tgQNAyzSUyg",
     "outputId": "6b015efb-3b36-4300-d932-f612dd39aee0"
@@ -2061,8 +2282,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_RBSUJuCd_qPnyz_zr_je</code> | Time: 27.7s</div><div style='margin-top: 10px;'><div id='B_OkPIQxin'>To tackle this task, I'll follow these steps:<br><br>1. **Retrieve Data**: I'll fetch 100 events from the `aws-s3-accesslogs` table in Databricks.<br>2. **Identify Interesting Columns**: I'll examine the data to identify columns that could be interesting for graph creation.<br>3. **Create a Graph**: Using the identified columns, I'll create a graph to visualize the relationships.<br><br>Let's get started!<br><br>### Step 1: Retrieve Data<br>I'll begin by fetching 100 events from the `aws-s3-accesslogs` table in Databricks.<br><br>DatabricksAgent<br>Get 100 rows from the aws-s3-accesslogs table<br>It seems there is a persistent issue with retrieving data from the `aws-s3-accesslogs` table in Databricks. The error indicates that the table or view cannot be found, which suggests a potential problem with the schema or catalog settings, or possibly a permissions issue.<br><br>Here's what you can do to resolve this:<br><br>1. **Double-check the Schema and Catalog**: Ensure that the schema and catalog are correctly specified in your query. You might want to use the fully qualified table name.<br><br>2. **Verify Permissions**: Make sure you have the necessary permissions to access the table. If you don't, you may need to contact your database administrator.<br><br>3. **Check Current Schema Settings**: Verify the current schema settings to ensure they are correct.<br><br>4. **Consult with a Database Administrator**: If the problem persists, it might be helpful to consult with your database administrator for further assistance.<br><br>If you need further help or have any other questions</div><div id='B_zlewhQ6x'><div style='color: gray;'>[CallElement] Get 100 rows from the aws-s3-accesslogs table\n",
-       "</div></div><div id='B_U07sxX_r'>It seems there is a recurring issue with retrieving data from the specified tables in the Databricks database. Despite confirming the existence of tables like 'o365-management-activity' and 'aws-s3-accesslogs' in the database, attempts to fetch data result in errors indicating that the tables or views cannot be found. This suggests potential problems with the schema or catalog settings, or possibly permissions issues. To resolve this, it is crucial to double-check the schema and catalog specifications in your queries, ensure you have the necessary permissions to access the tables, and verify the current schema settings. If the problem persists, consulting with your database administrator for further assistance would be advisable.</div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_FUvLplF6qCLsaNWIlj9Q</code> | Time: 37.7s</div><div style='margin-top: 10px;'><div id='B_S0lnfEC3'>The task involves retrieving 100 events from the 'o365_management_activity_flat_tcook' table in Databricks and then creating a graph using interesting columns for investigation. <br><br>Plan:<br>1. Use the DatabricksAgent to fetch 100 events from the 'o365_management_activity_flat_tcook' table.<br>2. Identify interesting columns for graph creation, such as 'ClientIP', 'UserId', 'Operation', and 'CreationTime'.<br>3. Use the GraphAgent to create a graph using these columns to visualize relationships and interactions.<br><br>DatabricksAgent<br>get 100 events from the o365_management_activity_flat_tcook table in DatabricksThe data has been successfully retrieved from the 'o365_management_activity_flat_tcook' table in Databricks. Now, let's create a graph using interesting columns such as 'ClientIP', 'UserId', 'Operation', and 'CreationTime' to visualize relationships and interactions.<br><br>Plan:<br>1. Use the GraphAgent to create a graph using the retrieved data.<br>2. Focus on columns 'ClientIP', 'UserId', 'Operation', and 'CreationTime' to highlight user interactions and activities.<br><br>GraphAgent<br>Create a graph using dataframe B_kEJv1cDD with columns 'ClientIP', 'UserId', 'Operation', and 'CreationTime'The graph has been successfully created using the specified columns 'ClientIP', 'UserId', 'Operation', and 'CreationTime' from the 'o365_management_activity_flat_tcook' table. This visualization highlights the relationships and interactions between different users and operations over time, providing insights into user activities and potential anomalies. If you have any specific questions or need further analysis</div><div id='B_r3CQZYOI'><div style='color: gray;'>[CallElement] get 100 events from the o365_management_activity_flat_tcook table in Databricks</div></div><div id='B_kAkfNlHY'>The query successfully retrieved 100 events from the 'o365_management_activity_flat_tcook' table. The data encompasses a wide range of details, including 'ClientIP', 'CreationTime', 'EventSource', and 'Operation', among others. The events are predominantly related to SharePoint activities, with various operations such as file previews, file modifications, and search queries. Notably, the user 'fyodor@froth.ly' frequently appears in these events, indicating significant activity on the platform. This dataset provides valuable insights into user interactions with SharePoint, highlighting document access, modifications, and search activities, which can be crucial for understanding user behavior and system usage patterns.</div><div id='B_lgBUD5U0'>fetching data</div><div id='B_O7bnf1_P'>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook` LIMIT 100</div><div id='B_B0VybR20'><div style='background: #f0f0f0; padding: 5px; margin: 5px 0;'>📊 DataFrame: B_B0VybR20 (shape: 100 x 25)</div></div><div id='B_uzSzgWzU'><div style='color: gray;'>[CallElement] Create a graph using dataframe B_kEJv1cDD with columns 'ClientIP', 'UserId', 'Operation', and 'CreationTime'</div></div><div id='B_Nn2pooCh'>The graph has been successfully created using the specified dataframe B_kEJv1cDD with the columns 'ClientIP', 'UserId', 'Operation', and 'CreationTime'. The graph consists of nodes and edges that represent the relationships between these entities. The nodes are defined by the 'ClientIP', 'UserId', and 'Operation', while the edges connect these nodes based on the 'CreationTime'. This visualization can help in understanding the interactions and operations performed by different users from various client IPs over time. The graph provides a clear representation of the data, making it easier to analyze patterns and identify any anomalies in user activities.</div><div id='B_qquoB8wq'><div style=\"margin: 10px 0;\"><iframe src=\"https:////hub.graphistry.com/graph/graph.html?dataset=22d43c465a9d4ed49c8ea6b948ae2234\" width=\"100%\" height=\"600\" style=\"border: 1px solid #ddd; border-radius: 5px;\"></iframe><div style=\"text-align: center; margin-top: 5px;\"><a href=\"https:////hub.graphistry.com/graph/graph.html?dataset=22d43c465a9d4ed49c8ea6b948ae2234\" target=\"_blank\" style=\"color: #0066cc; text-decoration: none;\">🔗 Open graph in new tab</a></div></div></div><div id='B_QGqfBb6L'>GraphAgent hypergraph<br>```python<br>graphistry.hypergraph(df, params={'entity_types': ['ClientIP', 'UserId', 'Operation', 'CreationTime'], 'direct': True})<br>```</div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -2076,18 +2296,334 @@
       "text/html": [
        "<div style='border: 1px solid #ddd; padding: 10px; border-radius: 5px; margin-bottom: 10px;'>\n",
        "<h4 style='margin-top: 0;'>🤖 LouieAI Response</h4>\n",
-       "<div>To tackle this task, I&#x27;ll follow these steps:</p><p>1. **Retrieve Data**: I&#x27;ll fetch 100 events from the `aws-s3-accesslogs` table in Databricks.<br>2. **Identify Interesting Columns**: I&#x27;ll examine the data to identify columns that could be interesting for graph creation.<br>3. **Create a Graph**: Using the identified columns, I&#x27;ll create a graph to visualize the relationships.</p><p>Let&#x27;s get started!</p><p>### Step 1: Retrieve Data<br>I&#x27;ll begin by fetching 100 events from the `aws-s3-accesslogs` table in Databricks.</p><p>DatabricksAgent<br>Get 100 rows from the aws-s3-accesslogs table<br>It seems there is a persistent issue with retrieving data from the `aws-s3-accesslogs` table in Databricks. The error indicates that the table or view cannot be found, which suggests a potential problem with the schema or catalog settings, or possibly a permissions issue.</p><p>Here&#x27;s what you can do to resolve this:</p><p>1. **Double-check the Schema and Catalog**: Ensure that the schema and catalog are correctly specified in your query. You might want to use the fully qualified table name.</p><p>2. **Verify Permissions**: Make sure you have the necessary permissions to access the table. If you don&#x27;t, you may need to contact your database administrator.</p><p>3. **Check Current Schema Settings**: Verify the current schema settings to ensure they are correct.</p><p>4. **Consult with a Database Administrator**: If the problem persists, it might be helpful to consult with your database administrator for further assistance.</p><p>If you need further help or have any other questions</div>\n",
-       "<div style='color: gray;'>[CallElement] Get 100 rows from the aws-s3-accesslogs table\n",
+       "<div>The task involves retrieving 100 events from the &#x27;o365_management_activity_flat_tcook&#x27; table in Databricks and then creating a graph using interesting columns for investigation. </p><p>Plan:<br>1. Use the DatabricksAgent to fetch 100 events from the &#x27;o365_management_activity_flat_tcook&#x27; table.<br>2. Identify interesting columns for graph creation, such as &#x27;ClientIP&#x27;, &#x27;UserId&#x27;, &#x27;Operation&#x27;, and &#x27;CreationTime&#x27;.<br>3. Use the GraphAgent to create a graph using these columns to visualize relationships and interactions.</p><p>DatabricksAgent<br>get 100 events from the o365_management_activity_flat_tcook table in DatabricksThe data has been successfully retrieved from the &#x27;o365_management_activity_flat_tcook&#x27; table in Databricks. Now, let&#x27;s create a graph using interesting columns such as &#x27;ClientIP&#x27;, &#x27;UserId&#x27;, &#x27;Operation&#x27;, and &#x27;CreationTime&#x27; to visualize relationships and interactions.</p><p>Plan:<br>1. Use the GraphAgent to create a graph using the retrieved data.<br>2. Focus on columns &#x27;ClientIP&#x27;, &#x27;UserId&#x27;, &#x27;Operation&#x27;, and &#x27;CreationTime&#x27; to highlight user interactions and activities.</p><p>GraphAgent<br>Create a graph using dataframe B_kEJv1cDD with columns &#x27;ClientIP&#x27;, &#x27;UserId&#x27;, &#x27;Operation&#x27;, and &#x27;CreationTime&#x27;The graph has been successfully created using the specified columns &#x27;ClientIP&#x27;, &#x27;UserId&#x27;, &#x27;Operation&#x27;, and &#x27;CreationTime&#x27; from the &#x27;o365_management_activity_flat_tcook&#x27; table. This visualization highlights the relationships and interactions between different users and operations over time, providing insights into user activities and potential anomalies. If you have any specific questions or need further analysis</div>\n",
+       "<div style='color: gray;'>[CallElement] get 100 events from the o365_management_activity_flat_tcook table in Databricks</div>\n",
+       "<div>The query successfully retrieved 100 events from the &#x27;o365_management_activity_flat_tcook&#x27; table. The data encompasses a wide range of details, including &#x27;ClientIP&#x27;, &#x27;CreationTime&#x27;, &#x27;EventSource&#x27;, and &#x27;Operation&#x27;, among others. The events are predominantly related to SharePoint activities, with various operations such as file previews, file modifications, and search queries. Notably, the user &#x27;fyodor@froth.ly&#x27; frequently appears in these events, indicating significant activity on the platform. This dataset provides valuable insights into user interactions with SharePoint, highlighting document access, modifications, and search activities, which can be crucial for understanding user behavior and system usage patterns.</div>\n",
+       "<div>fetching data</div>\n",
+       "<div>SELECT * FROM `client_demos`.`botsv3`.`o365_management_activity_flat_tcook` LIMIT 100</div>\n",
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ClientIP</th>\n",
+       "      <th>CorrelationId</th>\n",
+       "      <th>CreationTime</th>\n",
+       "      <th>EventSource</th>\n",
+       "      <th>Id</th>\n",
+       "      <th>ImplicitShare</th>\n",
+       "      <th>ItemType</th>\n",
+       "      <th>ListId</th>\n",
+       "      <th>ListItemUniqueId</th>\n",
+       "      <th>ObjectId</th>\n",
+       "      <th>...</th>\n",
+       "      <th>SourceFileExtension</th>\n",
+       "      <th>SourceFileName</th>\n",
+       "      <th>SourceRelativeUrl</th>\n",
+       "      <th>UserAgent</th>\n",
+       "      <th>UserId</th>\n",
+       "      <th>UserKey</th>\n",
+       "      <th>UserType</th>\n",
+       "      <th>Version</th>\n",
+       "      <th>WebId</th>\n",
+       "      <th>Workload</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-d0dd-6000-daf9-da44fcd45d4e</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>8a1fd9ad-95d3-4bea-a806-08d5f28ec619</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>37ab8c26-f775-4a03-97b3-074c81a00f33</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>beverages-02-00034-v2.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-60d3-6000-32f0-2235e1b3a20b</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>7d1dd9e0-63b3-4277-7a03-08d5f28ec5e3</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>bb017930-2bf5-4953-b38a-716ba3217703</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>craftbeerdotcom-beer-styles.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>107.77.213.173</td>\n",
+       "      <td>9e627e9e-a0db-6000-daf9-da5a21ed5a92</td>\n",
+       "      <td>2018-08-20T13:16:56</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>f5ad6c89-25b3-420c-f889-08d5f28ec656</td>\n",
+       "      <td>No</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>456e3291-27ad-455e-9cb7-a01722ffa0fa</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/fyo...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>fundamental of beer and hop chemistry.pdf</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>OneDriveMpc/1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>40.97.148.181</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
+       "      <td>2018-08-20T13:16:54</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>0ad166f0-5312-4e35-e017-08d5f28ec4fb</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Web</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>fa2fd17c-daf8-4062-8f87-d411eb537314</td>\n",
+       "      <td>...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Substrate Search 1.0</td>\n",
+       "      <td>fyodor@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffda2e71ff9@live.com</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>SharePoint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>104.238.59.42</td>\n",
+       "      <td>0a627e9e-f0d0-6000-daf9-dc8f468313e3</td>\n",
+       "      <td>2018-08-20T13:06:50</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>9b5ad97e-f03f-4648-a536-08d5f28d5cad</td>\n",
+       "      <td>None</td>\n",
+       "      <td>File</td>\n",
+       "      <td>67091393-e290-421e-ac6a-2734e2b12a94</td>\n",
+       "      <td>d2c4bb13-c97e-4707-9e9b-53dc0e2513b5</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/pce...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pptx</td>\n",
+       "      <td>Beer styles.pptx</td>\n",
+       "      <td>Documents</td>\n",
+       "      <td>Microsoft Office PowerPoint 2014</td>\n",
+       "      <td>pcerf@froth.ly</td>\n",
+       "      <td>i:0h.f|membership|1003bffdac730049@live.com</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>7acb35b6-e1ec-44ed-9099-38580e330ed0</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>104.209.132.239</td>\n",
+       "      <td>2fd04f66-77cc-415f-2155-08d5f269d0d3</td>\n",
+       "      <td>2018-08-20T11:32:08</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>dab49c4d-7681-42d2-bba8-08d5f26a57eb</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>File</td>\n",
+       "      <td>3f63cc5d-d2b8-4a9f-bc5f-255534837703</td>\n",
+       "      <td>ef167dd3-18b5-4962-bbbe-bd0afc11c3eb</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/jac...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NES</td>\n",
+       "      <td>MAIN.NES</td>\n",
+       "      <td>Documents/NESPack</td>\n",
+       "      <td>ExportWorker</td>\n",
+       "      <td>app@sharepoint</td>\n",
+       "      <td>i:0i.t|00000003-0000-0ff1-ce00-000000000000|ap...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0165abc4-c020-47fb-bb69-511981a12dbf</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>104.209.132.239</td>\n",
+       "      <td>2fd04f66-77cc-415f-2155-08d5f269d0d3</td>\n",
+       "      <td>2018-08-20T11:32:08</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>145f7516-0ebe-46b4-2db3-08d5f26a57a9</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>File</td>\n",
+       "      <td>4a006be3-198c-4a2b-a996-62e64cdc9d7d</td>\n",
+       "      <td>ed3d5448-a81e-498a-ad04-455ff8173228</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/gho...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>Belgian Lambic Blend 3278.pdf</td>\n",
+       "      <td>Documents/Frothly-Shared/Yeasts</td>\n",
+       "      <td>ExportWorker</td>\n",
+       "      <td>app@sharepoint</td>\n",
+       "      <td>i:0i.t|00000003-0000-0ff1-ce00-000000000000|ap...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>46ca8820-8a7b-46eb-b077-7d9024e32b39</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>104.209.132.239</td>\n",
+       "      <td>2fd04f66-77cc-415f-2155-08d5f269d0d3</td>\n",
+       "      <td>2018-08-20T11:32:08</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>f1a27022-f1ab-430e-f477-08d5f26a5790</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>File</td>\n",
+       "      <td>4a006be3-198c-4a2b-a996-62e64cdc9d7d</td>\n",
+       "      <td>e220cbc7-e981-406b-b4ac-7bbf18ed5c41</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/gho...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>37354-pdf.pdf</td>\n",
+       "      <td>Documents/Frothly-Shared/Yeasts</td>\n",
+       "      <td>ExportWorker</td>\n",
+       "      <td>app@sharepoint</td>\n",
+       "      <td>i:0i.t|00000003-0000-0ff1-ce00-000000000000|ap...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>46ca8820-8a7b-46eb-b077-7d9024e32b39</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>104.209.132.239</td>\n",
+       "      <td>2fd04f66-77cc-415f-2155-08d5f269d0d3</td>\n",
+       "      <td>2018-08-20T11:32:07</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>003f1764-fc13-4326-ecb0-08d5f26a570e</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>File</td>\n",
+       "      <td>ac9249b5-51e5-42e7-b3f1-f0c6e4674046</td>\n",
+       "      <td>e72bdf4d-f31c-4c93-aedc-6fa355ae3eff</td>\n",
+       "      <td>https://frothly.sharepoint.com/sites/Frothly_S...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>ods</td>\n",
+       "      <td>Come Again Double Cream Ale.ods</td>\n",
+       "      <td>Shared Documents/specialty_beer</td>\n",
+       "      <td>ExportWorker</td>\n",
+       "      <td>app@sharepoint</td>\n",
+       "      <td>i:0i.t|00000003-0000-0ff1-ce00-000000000000|ap...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>ed17c246-9def-4400-94c0-4fb39271e7cf</td>\n",
+       "      <td>SharePoint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>104.209.132.239</td>\n",
+       "      <td>2fd04f66-77cc-415f-2155-08d5f269d0d3</td>\n",
+       "      <td>2018-08-20T11:32:07</td>\n",
+       "      <td>SharePoint</td>\n",
+       "      <td>3c37185a-ad49-40a4-ceef-08d5f26a5768</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>File</td>\n",
+       "      <td>4a006be3-198c-4a2b-a996-62e64cdc9d7d</td>\n",
+       "      <td>e7ffe5fb-a387-445f-99cf-ee80c285a28e</td>\n",
+       "      <td>https://frothly-my.sharepoint.com/personal/gho...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>pdf</td>\n",
+       "      <td>39955-pdf.pdf</td>\n",
+       "      <td>Documents/Frothly-Shared/Yeasts</td>\n",
+       "      <td>ExportWorker</td>\n",
+       "      <td>app@sharepoint</td>\n",
+       "      <td>i:0i.t|00000003-0000-0ff1-ce00-000000000000|ap...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>46ca8820-8a7b-46eb-b077-7d9024e32b39</td>\n",
+       "      <td>OneDrive</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 25 columns</p>\n",
        "</div>\n",
-       "<div>It seems there is a recurring issue with retrieving data from the specified tables in the Databricks database. Despite confirming the existence of tables like &#x27;o365-management-activity&#x27; and &#x27;aws-s3-accesslogs&#x27; in the database, attempts to fetch data result in errors indicating that the tables or views cannot be found. This suggests potential problems with the schema or catalog settings, or possibly permissions issues. To resolve this, it is crucial to double-check the schema and catalog specifications in your queries, ensure you have the necessary permissions to access the tables, and verify the current schema settings. If the problem persists, consulting with your database administrator for further assistance would be advisable.</div>\n",
+       "<div style='color: gray;'>[CallElement] Create a graph using dataframe B_kEJv1cDD with columns 'ClientIP', 'UserId', 'Operation', and 'CreationTime'</div>\n",
+       "<div>The graph has been successfully created using the specified dataframe B_kEJv1cDD with the columns &#x27;ClientIP&#x27;, &#x27;UserId&#x27;, &#x27;Operation&#x27;, and &#x27;CreationTime&#x27;. The graph consists of nodes and edges that represent the relationships between these entities. The nodes are defined by the &#x27;ClientIP&#x27;, &#x27;UserId&#x27;, and &#x27;Operation&#x27;, while the edges connect these nodes based on the &#x27;CreationTime&#x27;. This visualization can help in understanding the interactions and operations performed by different users from various client IPs over time. The graph provides a clear representation of the data, making it easier to analyze patterns and identify any anomalies in user activities.</div>\n",
+       "<div style=\"margin: 10px 0;\"><iframe src=\"https:////hub.graphistry.com/graph/graph.html?dataset=22d43c465a9d4ed49c8ea6b948ae2234\" width=\"100%\" height=\"600\" style=\"border: 1px solid #ddd; border-radius: 5px;\"></iframe><div style=\"text-align: center; margin-top: 5px;\"><a href=\"https:////hub.graphistry.com/graph/graph.html?dataset=22d43c465a9d4ed49c8ea6b948ae2234\" target=\"_blank\" style=\"color: #0066cc; text-decoration: none;\">🔗 Open graph in new tab</a></div></div>\n",
+       "<div>GraphAgent hypergraph<br>```python<br>graphistry.hypergraph(df, params={&#x27;entity_types&#x27;: [&#x27;ClientIP&#x27;, &#x27;UserId&#x27;, &#x27;Operation&#x27;, &#x27;CreationTime&#x27;], &#x27;direct&#x27;: True})<br>```</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_RBSUJuCd_qPnyz_zr_je</code> | <a href='https://louie.graphistry.com/?dthread=D_RBSUJuCd_qPnyz_zr_je' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_FUvLplF6qCLsaNWIlj9Q</code> | <a href='https://louie.graphistry.com/?dthread=D_FUvLplF6qCLsaNWIlj9Q' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 6 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
        "<p><b>Latest Response:</b></p>\n",
        "<ul style='margin: 5px 0;'>\n",
-       "<li>2 text element(s) - access with <code>lui.text</code> or <code>lui.texts</code></li>\n",
+       "<li>6 text element(s) - access with <code>lui.text</code> or <code>lui.texts</code></li>\n",
+       "<li>1 dataframe(s) - access with <code>lui.df</code> or <code>lui.dfs</code></li>\n",
        "</ul>\n",
        "<details><summary><b>Quick Help</b> (click to expand)</summary>\n",
        "<pre style='margin: 10px 0; padding: 10px; background: #f5f5f5;'>\n",
@@ -2129,7 +2665,7 @@
        "</div>"
       ],
       "text/plain": [
-       "<LouieAI Notebook Interface | Session: Active | History: 6 responses | Traces: Disabled | Latest: 2 text>"
+       "<LouieAI Notebook Interface | Session: Active | History: 6 responses | Traces: Disabled | Latest: 6 text, 1 dataframe>"
       ]
      },
      "execution_count": 17,
@@ -2140,7 +2676,7 @@
    "source": [
     "lui(\"\"\"\n",
     "\n",
-    "Get 100 events from databricks aws-s3-accesslogs and\n",
+    "Get 100 events from databricks o365_management_activity_flat_tcook and\n",
     "draw a graph using any intereseting sounding columns for investigating\n",
     "\n",
     "\"\"\")"
@@ -2177,10 +2713,10 @@
      "height": 130
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:32:09.413762Z",
-     "iopub.status.busy": "2025-08-04T02:32:09.413580Z",
-     "iopub.status.idle": "2025-08-04T02:32:19.589934Z",
-     "shell.execute_reply": "2025-08-04T02:32:19.589484Z"
+     "iopub.execute_input": "2025-08-04T04:33:01.923043Z",
+     "iopub.status.busy": "2025-08-04T04:33:01.922929Z",
+     "iopub.status.idle": "2025-08-04T04:33:05.609922Z",
+     "shell.execute_reply": "2025-08-04T04:33:05.609420Z"
     },
     "id": "TQLcynwz0P_A",
     "outputId": "9ceeadf9-05ea-4058-eb31-e74363bf2d33"
@@ -2189,7 +2725,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_oROfgZn1wBwTuDWUYrpS</code> | Time: 10.2s</div><div style='margin-top: 10px;'><div id='B_nggEAvJh'>The best jokes are about </div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_yuqesrqt5j_FKXnlEGOI</code> | Time: 3.7s</div><div style='margin-top: 10px;'><div id='B_Rks6TYrr'>The best jokes are about 19th century scientists</div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -2201,7 +2737,7 @@
     {
      "data": {
       "text/plain": [
-       "'D_oROfgZn1wBwTuDWUYrpS'"
+       "'D_yuqesrqt5j_FKXnlEGOI'"
       ]
      },
      "execution_count": 18,
@@ -2226,10 +2762,10 @@
      "height": 1000
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:32:19.591826Z",
-     "iopub.status.busy": "2025-08-04T02:32:19.591640Z",
-     "iopub.status.idle": "2025-08-04T02:32:31.386155Z",
-     "shell.execute_reply": "2025-08-04T02:32:31.385687Z"
+     "iopub.execute_input": "2025-08-04T04:33:05.611771Z",
+     "iopub.status.busy": "2025-08-04T04:33:05.611581Z",
+     "iopub.status.idle": "2025-08-04T04:33:15.748991Z",
+     "shell.execute_reply": "2025-08-04T04:33:15.748499Z"
     },
     "id": "QYVeLQzO5oiy",
     "outputId": "d9960719-4fbb-4bc0-c48f-37c070509a3b"
@@ -2238,7 +2774,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_rsqUnv18KVOHk97UMyhS</code> | Time: 11.8s</div><div style='margin-top: 10px;'><div id='B_2lvsJXBE'>I need to read the specified dthread first to understand its content before making a joke about it.<br>NotebookAgent<br>read dthread D_oROfgZn1wBwTuDWUYrpSFinal Answer: The dthread humorously suggests that the best jokes are about 19th-century scientists. So here's a joke for you: Why did the 19th-century scientist always carry a barometer?</div><div id='B_p34_8axv'><div style='color: gray;'>[CallElement] read dthread D_oROfgZn1wBwTuDWUYrpS</div></div><div id='B_VDYEzAqX'><notebook id=\"D_oROfgZn1wBwTuDWUYrpS\"><br>  <cells><br>    <cell id=\"B_7YeBQr4j\" agent=\"LouieAgent\" last_run_id=\"None\"><br>      <inputs><br>        <element type=\"TextElement\"> | Markdown: </element><br>      </inputs><br>      <outputs/><br>    </cell><br>    <cell id=\"B_BMwC3JDI\" agent=\"LouieAgent\" last_run_id=\"R_cDWJpEmvN7q1QD4CpW5V\"><br>      <inputs><br>        <element type=\"TextElement\"> | Markdown: Repeat this out: The best jokes are about 19th century scientists</element><br>      </inputs><br>      <outputs><br>        <element type=\"TextElement\"> | Markdown: The best jokes are about 19th century scientists!</element><br>      </outputs><br>      <run id=\"R_cDWJpEmvN7q1QD4CpW5V\" state=\"Done\" run_type=\"LouieAgent\"><br>        <traces><br>          <trace level=\"Level.INFO\">LouieAgent::runner</trace><br>          <trace level=\"Level.DEBUG\">Input text:::Repeat this out: The best jokes are about 19th century scientists</trace><br>          <trace level=\"Level.DEBUG\">Reading chat history. (is_prepared: True)</trace><br>          <trace level=\"Level.DEBUG\">...</trace><br>          <trace level=\"Level.INFO\">Louie output text: The best jokes are about 19th century scientists!</trace><br>        </traces><br>      </run><br>    </cell><br>  </cells><br></notebook></div><div id='B_3SRjsLKz'>The notebook with the ID \"D_oROfgZn1wBwTuDWUYrpS\" contains a humorous statement emphasizing that the best jokes are about 19th-century scientists. This suggests a playful engagement with historical scientific figures, possibly highlighting their quirks or contributions in a light-hearted manner. The content reflects a blend of humor and historical interest, appealing to those who appreciate both science and wit.</div></div></div>"
+       "<div style='border: 1px solid #ddd; padding: 15px; border-radius: 5px;'><h4 style='margin-top: 0;'>🤖 LouieAI Response</h4><div style='font-size: 0.8em; color: #666; margin-bottom: 10px;'>Thread: <code>D_aaFSFDiWRUkaqmPpF7QK</code> | Time: 10.1s</div><div style='margin-top: 10px;'><div id='B_rkUNlcSq'>Sure thing! Let's dive into the dthread D_yuqesrqt5j_FKXnlEGOI first, and then I'll whip up a joke for you. <br><br>I need to read the specified dthread to understand its content before making a joke.<br>NotebookAgent<br>read dthread D_yuqesrqt5j_FKXnlEGOIThe dthread D_yuqesrqt5j_FKXnlEGOI contains a simple task where the LouieAgent was asked to repeat the statement: \"The best jokes are about 19th century scientists.\" Now, let's have some fun with that!<br><br>Why did the 19th century scientist always carry a barometer? Because he couldn't resist the pressure! <br><br>Hope that brings a smile to your face! If you need more data magic or humor, just</div><div id='B_bhP9KEfr'><div style='color: gray;'>[CallElement] read dthread D_yuqesrqt5j_FKXnlEGOI</div></div><div id='B_hfOSOc3T'><notebook id=\"D_yuqesrqt5j_FKXnlEGOI\"><br>  <cells><br>    <cell id=\"B_oCbudpf7\" agent=\"LouieAgent\" last_run_id=\"None\"><br>      <inputs><br>        <element type=\"TextElement\"> | Markdown: </element><br>      </inputs><br>      <outputs/><br>    </cell><br>    <cell id=\"B_DOzO7GCg\" agent=\"LouieAgent\" last_run_id=\"R_Ma3m1t2JLsl1WKzz1hvD\"><br>      <inputs><br>        <element type=\"TextElement\"> | Markdown: Repeat this out: The best jokes are about 19th century scientists</element><br>      </inputs><br>      <outputs><br>        <element type=\"TextElement\"> | Markdown: The best jokes are about 19th century scientists!</element><br>      </outputs><br>      <run id=\"R_Ma3m1t2JLsl1WKzz1hvD\" state=\"Done\" run_type=\"LouieAgent\"><br>        <traces><br>          <trace level=\"Level.INFO\">LouieAgent::runner</trace><br>          <trace level=\"Level.DEBUG\">Input text:::Repeat this out: The best jokes are about 19th century scientists</trace><br>          <trace level=\"Level.DEBUG\">Reading chat history. (is_prepared: True)</trace><br>          <trace level=\"Level.DEBUG\">...</trace><br>          <trace level=\"Level.INFO\">Louie output text: The best jokes are about 19th century scientists!</trace><br>        </traces><br>      </run><br>    </cell><br>  </cells><br></notebook></div><div id='B_9mXXZSLt'>The notebook with the ID \"D_yuqesrqt5j_FKXnlEGOI\" contains a single cell where the LouieAgent was prompted to repeat a statement about jokes. The input was \"Repeat this out: The best jokes are about 19th century scientists,\" and the output was the same statement, confirming the agent's ability to process and echo the input text. This simple task demonstrates the agent's functionality in handling text repetition tasks.</div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -2252,12 +2788,12 @@
       "text/html": [
        "<div style='border: 1px solid #ddd; padding: 10px; border-radius: 5px; margin-bottom: 10px;'>\n",
        "<h4 style='margin-top: 0;'>🤖 LouieAI Response</h4>\n",
-       "<div>I need to read the specified dthread first to understand its content before making a joke about it.<br>NotebookAgent<br>read dthread D_oROfgZn1wBwTuDWUYrpSFinal Answer: The dthread humorously suggests that the best jokes are about 19th-century scientists. So here&#x27;s a joke for you: Why did the 19th-century scientist always carry a barometer?</div>\n",
-       "<div style='color: gray;'>[CallElement] read dthread D_oROfgZn1wBwTuDWUYrpS</div>\n",
-       "<div>&lt;notebook id=&quot;D_oROfgZn1wBwTuDWUYrpS&quot;&gt;<br>  &lt;cells&gt;<br>    &lt;cell id=&quot;B_7YeBQr4j&quot; agent=&quot;LouieAgent&quot; last_run_id=&quot;None&quot;&gt;<br>      &lt;inputs&gt;<br>        &lt;element type=&quot;TextElement&quot;&gt; | Markdown: &lt;/element&gt;<br>      &lt;/inputs&gt;<br>      &lt;outputs/&gt;<br>    &lt;/cell&gt;<br>    &lt;cell id=&quot;B_BMwC3JDI&quot; agent=&quot;LouieAgent&quot; last_run_id=&quot;R_cDWJpEmvN7q1QD4CpW5V&quot;&gt;<br>      &lt;inputs&gt;<br>        &lt;element type=&quot;TextElement&quot;&gt; | Markdown: Repeat this out: The best jokes are about 19th century scientists&lt;/element&gt;<br>      &lt;/inputs&gt;<br>      &lt;outputs&gt;<br>        &lt;element type=&quot;TextElement&quot;&gt; | Markdown: The best jokes are about 19th century scientists!&lt;/element&gt;<br>      &lt;/outputs&gt;<br>      &lt;run id=&quot;R_cDWJpEmvN7q1QD4CpW5V&quot; state=&quot;Done&quot; run_type=&quot;LouieAgent&quot;&gt;<br>        &lt;traces&gt;<br>          &lt;trace level=&quot;Level.INFO&quot;&gt;LouieAgent::runner&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.DEBUG&quot;&gt;Input text:::Repeat this out: The best jokes are about 19th century scientists&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.DEBUG&quot;&gt;Reading chat history. (is_prepared: True)&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.DEBUG&quot;&gt;...&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.INFO&quot;&gt;Louie output text: The best jokes are about 19th century scientists!&lt;/trace&gt;<br>        &lt;/traces&gt;<br>      &lt;/run&gt;<br>    &lt;/cell&gt;<br>  &lt;/cells&gt;<br>&lt;/notebook&gt;</div>\n",
-       "<div>The notebook with the ID &quot;D_oROfgZn1wBwTuDWUYrpS&quot; contains a humorous statement emphasizing that the best jokes are about 19th-century scientists. This suggests a playful engagement with historical scientific figures, possibly highlighting their quirks or contributions in a light-hearted manner. The content reflects a blend of humor and historical interest, appealing to those who appreciate both science and wit.</div>\n",
+       "<div>Sure thing! Let&#x27;s dive into the dthread D_yuqesrqt5j_FKXnlEGOI first, and then I&#x27;ll whip up a joke for you. </p><p>I need to read the specified dthread to understand its content before making a joke.<br>NotebookAgent<br>read dthread D_yuqesrqt5j_FKXnlEGOIThe dthread D_yuqesrqt5j_FKXnlEGOI contains a simple task where the LouieAgent was asked to repeat the statement: &quot;The best jokes are about 19th century scientists.&quot; Now, let&#x27;s have some fun with that!</p><p>Why did the 19th century scientist always carry a barometer? Because he couldn&#x27;t resist the pressure! </p><p>Hope that brings a smile to your face! If you need more data magic or humor, just</div>\n",
+       "<div style='color: gray;'>[CallElement] read dthread D_yuqesrqt5j_FKXnlEGOI</div>\n",
+       "<div>&lt;notebook id=&quot;D_yuqesrqt5j_FKXnlEGOI&quot;&gt;<br>  &lt;cells&gt;<br>    &lt;cell id=&quot;B_oCbudpf7&quot; agent=&quot;LouieAgent&quot; last_run_id=&quot;None&quot;&gt;<br>      &lt;inputs&gt;<br>        &lt;element type=&quot;TextElement&quot;&gt; | Markdown: &lt;/element&gt;<br>      &lt;/inputs&gt;<br>      &lt;outputs/&gt;<br>    &lt;/cell&gt;<br>    &lt;cell id=&quot;B_DOzO7GCg&quot; agent=&quot;LouieAgent&quot; last_run_id=&quot;R_Ma3m1t2JLsl1WKzz1hvD&quot;&gt;<br>      &lt;inputs&gt;<br>        &lt;element type=&quot;TextElement&quot;&gt; | Markdown: Repeat this out: The best jokes are about 19th century scientists&lt;/element&gt;<br>      &lt;/inputs&gt;<br>      &lt;outputs&gt;<br>        &lt;element type=&quot;TextElement&quot;&gt; | Markdown: The best jokes are about 19th century scientists!&lt;/element&gt;<br>      &lt;/outputs&gt;<br>      &lt;run id=&quot;R_Ma3m1t2JLsl1WKzz1hvD&quot; state=&quot;Done&quot; run_type=&quot;LouieAgent&quot;&gt;<br>        &lt;traces&gt;<br>          &lt;trace level=&quot;Level.INFO&quot;&gt;LouieAgent::runner&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.DEBUG&quot;&gt;Input text:::Repeat this out: The best jokes are about 19th century scientists&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.DEBUG&quot;&gt;Reading chat history. (is_prepared: True)&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.DEBUG&quot;&gt;...&lt;/trace&gt;<br>          &lt;trace level=&quot;Level.INFO&quot;&gt;Louie output text: The best jokes are about 19th century scientists!&lt;/trace&gt;<br>        &lt;/traces&gt;<br>      &lt;/run&gt;<br>    &lt;/cell&gt;<br>  &lt;/cells&gt;<br>&lt;/notebook&gt;</div>\n",
+       "<div>The notebook with the ID &quot;D_yuqesrqt5j_FKXnlEGOI&quot; contains a single cell where the LouieAgent was prompted to repeat a statement about jokes. The input was &quot;Repeat this out: The best jokes are about 19th century scientists,&quot; and the output was the same statement, confirming the agent&#x27;s ability to process and echo the input text. This simple task demonstrates the agent&#x27;s functionality in handling text repetition tasks.</div>\n",
        "<hr style='margin: 10px 0;'>\n",
-       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_rsqUnv18KVOHk97UMyhS</code> | <a href='https://louie.graphistry.com/?dthread=D_rsqUnv18KVOHk97UMyhS' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
+       "<p style='margin: 5px 0; font-size: 0.9em;'>✅ <b>Session:</b> Active | <b>Thread ID:</b> <code>D_aaFSFDiWRUkaqmPpF7QK</code> | <a href='https://louie.graphistry.com/?dthread=D_aaFSFDiWRUkaqmPpF7QK' target='_blank'>View Thread ↗</a> | <b>Org:</b> example-org</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>📚 <b>History:</b> 1 responses\n",
        " (access with <code>lui[-1]</code>, <code>lui[-2]</code>, etc.)</p>\n",
        "<p style='margin: 5px 0; font-size: 0.9em;'>🔍 <b>Traces:</b> Disabled (use <code>lui.traces = True</code> to enable)</p>\n",
@@ -2327,10 +2863,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2025-08-04T02:32:31.387559Z",
-     "iopub.status.busy": "2025-08-04T02:32:31.387398Z",
-     "iopub.status.idle": "2025-08-04T02:32:31.389537Z",
-     "shell.execute_reply": "2025-08-04T02:32:31.389273Z"
+     "iopub.execute_input": "2025-08-04T04:33:15.750436Z",
+     "iopub.status.busy": "2025-08-04T04:33:15.750201Z",
+     "iopub.status.idle": "2025-08-04T04:33:15.752796Z",
+     "shell.execute_reply": "2025-08-04T04:33:15.752384Z"
     },
     "id": "0gJLMR3M6L3F",
     "outputId": "6e3de4f2-5162-498b-8424-b14051d1b1fd"
@@ -2340,9 +2876,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "I need to read the specified dthread first to understand its content before making a joke about it.\n",
+      "Sure thing! Let's dive into the dthread D_yuqesrqt5j_FKXnlEGOI first, and then I'll whip up a joke for you. \n",
+      "\n",
+      "I need to read the specified dthread to understand its content before making a joke.\n",
       "NotebookAgent\n",
-      "read dthread D_oROfgZn1wBwTuDWUYrpSFinal Answer: The dthread humorously suggests that the best jokes are about 19th-century scientists. So here's a joke for you: Why did the 19th-century scientist always carry a barometer?\n"
+      "read dthread D_yuqesrqt5j_FKXnlEGOIThe dthread D_yuqesrqt5j_FKXnlEGOI contains a simple task where the LouieAgent was asked to repeat the statement: \"The best jokes are about 19th century scientists.\" Now, let's have some fun with that!\n",
+      "\n",
+      "Why did the 19th century scientist always carry a barometer? Because he couldn't resist the pressure! \n",
+      "\n",
+      "Hope that brings a smile to your face! If you need more data magic or humor, just\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary
- Replace incorrect table names in vibes investigation tutorial notebook with `o365_management_activity_flat_tcook`
- Re-execute notebook to verify all queries work correctly
- Clean security-sensitive URLs

## Changes
- Updated all Databricks query cells to use `o365_management_activity_flat_tcook` instead of:
  - `o365-management-activity` (incorrect hyphenated name)
  - `aws-s3-accesslogs` (wrong table entirely)
- Re-executed notebook with test credentials showing successful data retrieval:
  - Cell 19: 10 rows retrieved
  - Cell 23: 4 events retrieved  
  - Cell 25: 4 events retrieved
  - Cell 27: 100 events retrieved with graph visualization
- Replaced dev URLs with generic hub.graphistry.com

## Test plan
- [x] Notebook executes without errors
- [x] All Databricks queries return expected data
- [x] Security validation passes (no credentials exposed)
- [x] CI quick checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)