### PR TITLE
Fix double display bug in Jupyter notebooks

### DIFF
--- a/src/louieai/notebook/cursor.py
+++ b/src/louieai/notebook/cursor.py
@@ -868,17 +868,11 @@ class Cursor:
                 "<div style='border: 1px solid #ddd; padding: 10px; "
                 "border-radius: 5px; margin-bottom: 10px;'>"
             ),
-            "<h4 style='margin-top: 0;'>🤖 LouieAI Response</h4>",
+            "<h4 style='margin-top: 0;'>🤖 LouieAI Session</h4>",
         ]
 
-        # Show latest response content if available
-        if self._history:
-            latest = self._history[-1]
-
-            # Use the shared renderer for consistent display
-            response_html = _render_response_html(latest, self._client)
-            if response_html:
-                html_parts.append(response_html)
+        # Note: Response content is displayed separately via streaming or _display()
+        # This shows only session metadata to avoid double display
 
         # Session info footer
         html_parts.append("<hr style='margin: 10px 0;'>")

--- a/tests/integration/test_notebook_experience.py
+++ b/tests/integration/test_notebook_experience.py
@@ -198,9 +198,9 @@ class TestNotebookExperience:
 
         # HTML repr
         html = lui._repr_html_()
-        assert "🤖 LouieAI Response" in html
-        assert "&lt;html&gt;" in html  # Escaped
-        assert "&amp; symbols" in html  # Escaped
+        assert "🤖 LouieAI Session" in html  # Changed from Response to Session
+        # Note: Content is no longer shown in _repr_html_ to avoid double display
+        # So HTML escaping tests are no longer relevant here
         assert "1 dataframe(s) - access with" in html
 
     def test_environment_variable_initialization(self):

--- a/tests/unit/notebook/test_cursor_display.py
+++ b/tests/unit/notebook/test_cursor_display.py
@@ -61,8 +61,8 @@ class TestCursorDisplay:
         assert "History: 1 responses" in repr_str
         assert "Latest: 1 text, 1 dataframe" in repr_str
 
-    def test_repr_html_displays_response_content(self):
-        """Test _repr_html_ shows actual response content."""
+    def test_repr_html_no_longer_shows_response_content(self):
+        """Test _repr_html_ no longer shows response content to avoid double display."""
         cursor = Cursor(client=MagicMock())
 
         # Add a response
@@ -79,18 +79,18 @@ class TestCursorDisplay:
 
         # Check structure
         assert "<h4" in html
-        assert "LouieAI Response" in html
+        assert "LouieAI Session" in html  # Changed from "Response"
 
-        # Check content is displayed
-        assert "Here is your song:" in html
-        assert "La la la!" in html
+        # Check content is NOT displayed (to avoid double display)
+        assert "Here is your song:" not in html
+        assert "La la la!" not in html
 
-        # Check metadata
+        # Check metadata IS still shown
         assert "Session:</b> Active" in html
         assert "History:</b> 1 responses" in html
 
-    def test_repr_html_escapes_content(self):
-        """Test that HTML content is properly escaped."""
+    def test_repr_html_shows_session_info(self):
+        """Test that _repr_html_ shows session information."""
         cursor = Cursor(client=MagicMock())
 
         # Add response with HTML-like content
@@ -101,12 +101,16 @@ class TestCursorDisplay:
             ],
         )
         cursor._history.append(mock_response)
+        cursor._current_thread = "test-thread"
 
         html = cursor._repr_html_()
 
-        # Should escape the script tag
-        assert "&lt;script&gt;" in html
+        # Should show session info but not content
+        assert "Session:</b> Active" in html
+        assert "Thread ID:</b> <code>test-thread</code>" in html
+        # Content should NOT be displayed (no XSS risk from _repr_html_)
         assert "<script>" not in html
+        assert "alert" not in html
 
     def test_repr_html_shows_dataframe_notice(self):
         """Test that dataframe availability is noted."""

--- a/tests/unit/notebook/test_help.py
+++ b/tests/unit/notebook/test_help.py
@@ -55,7 +55,7 @@ class TestHelpDiscovery:
         html = cursor._repr_html_()
 
         assert "<h4" in html
-        assert "LouieAI Response" in html
+        assert "LouieAI Session" in html  # Changed from Response to Session
         assert "Session:</b> Not started" in html
         assert "lui('your query')" in html
         assert "<details>" in html  # Quick help section
@@ -99,7 +99,7 @@ class TestHelpDiscovery:
 
             # Test _repr_html_ delegation
             html = lui._repr_html_()
-            assert "LouieAI Response" in html
+            assert "LouieAI Session" in html  # Changed from Response to Session
 
     def test_help_function_works(self):
         """Test Python's help() function provides useful info."""


### PR DESCRIPTION
## Summary
Fixes the double display issue where responses were shown twice when calling `lui("query")` in Jupyter notebooks.

## Problem
When `lui("query")` was executed in a Jupyter notebook, the response content was displayed twice:
1. Once through the streaming display or `_display()` method
2. Again through Jupyter's automatic rendering of the Cursor object's `_repr_html_` method

## Solution
Modified the `_repr_html_` method to show only session metadata (thread ID, history count, help text) instead of the actual response content. This prevents duplicate display while still providing useful session information when the cursor object is inspected.

## Changes
- Modified `src/louieai/notebook/cursor.py` - Changed `_repr_html_` to show only session info, not response content
- Updated test files to match new behavior:
  - `tests/unit/notebook/test_cursor_display.py` - Updated tests for new display format
  - `tests/unit/notebook/test_help.py` - Updated assertions to expect "LouieAI Session" instead of "LouieAI Response"
  - `tests/integration/test_notebook_experience.py` - Updated assertions for new display format

## Test Plan
- [x] All cursor display tests pass (9 tests)
- [x] MyPy type checking passes
- [x] Ruff linting passes
- [x] Code properly formatted
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)