### PR TITLE
feat: add W3C traceparent propagation for distributed tracing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -96,7 +96,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 3
+      "min_level": 2
     },
     {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
@@ -132,6 +132,30 @@
       ]
     }
   ],
-  "results": {},
-  "generated_at": "2025-09-23T23:57:52Z"
+  "results": {
+    "src/louieai/_client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/louieai/_client.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 177
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/louieai/_client.py",
+        "hashed_secret": "5dd797929e3974a4f849b21145a499ad7bda6dd4",
+        "is_verified": false,
+        "line_number": 184
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/louieai/_client.py",
+        "hashed_secret": "11c31bcdb36cf14121c0474d5948e332c7286386",
+        "is_verified": false,
+        "line_number": 320
+      }
+    ]
+  },
+  "generated_at": "2026-01-16T23:18:30Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,30 +132,6 @@
       ]
     }
   ],
-  "results": {
-    "src/louieai/_client.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/louieai/_client.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 177
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/louieai/_client.py",
-        "hashed_secret": "5dd797929e3974a4f849b21145a499ad7bda6dd4",
-        "is_verified": false,
-        "line_number": 184
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/louieai/_client.py",
-        "hashed_secret": "11c31bcdb36cf14121c0474d5948e332c7286386",
-        "is_verified": false,
-        "line_number": 320
-      }
-    ]
-  },
-  "generated_at": "2026-01-16T23:18:30Z"
+  "results": {},
+  "generated_at": "2026-01-16T23:24:34Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - None.
 
+## [0.7.0] - 2026-01-16
+
+### Added
+- **Distributed tracing**: W3C `traceparent` propagation for correlating requests with OpenTelemetry
+  - Automatic OTel context propagation when available
+  - Session-level trace ID for correlation when OTel is not configured
+  - `Cursor.new()` children inherit parent trace ID for session-wide correlation
+  - Zero configuration required - works automatically
+
+### Changed
+- `LouieClient._get_headers()` now accepts `session_trace_id` and `traceparent` parameters
+- All HTTP methods (`add_cell`, `upload_*`, streaming) propagate trace context
+
 ## [0.6.2] - 2025-12-22
 
 ### Added

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -130,3 +130,30 @@ User Query → Agent Selection → LouieAI API → Agent Processing → Structur
 - Real-time streaming with progressive updates
 - Automatic dataframe and visualization rendering
 - History management with indexed access (`lui[-1]`, `lui[-2]`, etc.)
+
+### Distributed Tracing (OpenTelemetry)
+
+LouieAI automatically propagates W3C `traceparent` headers for distributed tracing:
+
+**With OpenTelemetry configured:**
+```python
+# Your existing OTel span context is automatically propagated
+with tracer.start_as_current_span("my_analysis"):
+    lui("analyze data")  # Request includes your trace context
+```
+
+**Without OpenTelemetry:**
+```python
+# Session-level trace ID generated automatically for correlation
+lui = louieai.Cursor()
+lui("query 1")  # All requests share a session trace_id
+lui("query 2")  # Same trace_id, different span_id
+
+child = lui.new()
+child("query 3")  # Same session trace_id (inherited)
+```
+
+This enables:
+- Linking client requests to server-side traces in Tempo, Jaeger, etc.
+- Correlating all prompts within a Cursor session
+- No configuration required - works automatically

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ dev = [
   "mkdocs-jupyter>=0.24.0",
   "nbclient>=0.10.2",
   "python-dotenv>=1.0.0",
-  "ipython>=8.0.0"
+  "ipython>=8.0.0",
+  "opentelemetry-api>=1.0.0",  # For type checking OTel integration
 ]
 docs = [
   "mkdocs>=1.6.0",
@@ -141,6 +142,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "IPython.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "opentelemetry.*"
 ignore_missing_imports = true
 
 # Ignore mypy issues in test files for complex mocking

--- a/src/louieai/_client.py
+++ b/src/louieai/_client.py
@@ -18,6 +18,7 @@ from ._table_ai import (
     collect_table_ai_kwargs,
     normalize_table_ai_overrides,
 )
+from ._tracing import get_traceparent
 from .auth import AuthManager, auto_retry_auth
 
 logger = logging.getLogger(__name__)
@@ -368,8 +369,21 @@ class LouieClient:
             logger.debug("Full error details: ", exc_info=True)
             return None
 
-    def _get_headers(self) -> dict[str, str]:
-        """Get authorization headers using auth manager."""
+    def _get_headers(
+        self, session_trace_id: str | None = None, traceparent: str | None = None
+    ) -> dict[str, str]:
+        """Get authorization headers using auth manager.
+
+        Args:
+            session_trace_id: Optional session trace ID for correlation when
+                OTel is not available. Used to generate traceparent if no
+                explicit traceparent is provided and OTel is not active.
+            traceparent: Optional explicit traceparent header value. If provided,
+                takes precedence over auto-generated values.
+
+        Returns:
+            Headers dict with Authorization and optionally traceparent.
+        """
         token = self._auth_manager.get_token()
         headers = {"Authorization": f"Bearer {token}"}
 
@@ -382,6 +396,15 @@ class LouieClient:
             if org_name:  # Ensure org_name is not None
                 org_slug = self._to_slug(str(org_name))
                 headers["X-Graphistry-Org"] = org_slug
+
+        # Add traceparent for distributed tracing
+        # Priority: explicit traceparent > OTel context > session trace
+        if traceparent:
+            headers["traceparent"] = traceparent
+        else:
+            tp = get_traceparent(session_trace_id)
+            if tp:
+                headers["traceparent"] = tp
 
         return headers
 
@@ -619,6 +642,7 @@ class LouieClient:
         share_mode: str = "Private",
         table_ai_overrides: TableAIOverrides | Mapping[str, Any] | None = None,
         use_batch: bool | None = None,
+        session_trace_id: str | None = None,
         **legacy_overrides: Any,
     ) -> Response:
         """Add a cell (query) to a thread and get response.
@@ -634,13 +658,15 @@ class LouieClient:
             table_ai_overrides: Structured overrides via dataclass or mapping.
             use_batch: Force singleshot (`True`) or streaming (`False`); defaults to
                 singleshot when overrides are provided.
+            session_trace_id: Optional session trace ID for distributed tracing
+                correlation when OpenTelemetry is not available.
             **legacy_overrides: Backwards-compatible Table AI keyword arguments like
                 ``table_ai_semantic_mode``. Prefer `table_ai_overrides`.
 
         Returns:
             Response object containing thread_id and all elements
         """
-        headers = self._get_headers()
+        headers = self._get_headers(session_trace_id=session_trace_id)
 
         # Build query parameters
         params: dict[str, Any] = {
@@ -940,6 +966,7 @@ class LouieClient:
         name: str | None = None,
         folder: str | None = None,
         parsing_options: dict[str, Any] | None = None,
+        session_trace_id: str | None = None,
     ) -> Response:
         """Upload a DataFrame with a natural language query for AI analysis.
 
@@ -954,6 +981,8 @@ class LouieClient:
             name: Optional thread name
             folder: Optional folder path for the thread (server support required)
             parsing_options: Format-specific parsing options
+            session_trace_id: Optional session trace ID for distributed tracing
+                correlation when OpenTelemetry is not available.
 
         Returns:
             Response object with analysis results
@@ -975,6 +1004,7 @@ class LouieClient:
             name=name,
             folder=folder,
             parsing_options=parsing_options,
+            session_trace_id=session_trace_id,
         )
 
     def upload_image(
@@ -988,6 +1018,7 @@ class LouieClient:
         share_mode: str = "Private",
         name: str | None = None,
         folder: str | None = None,
+        session_trace_id: str | None = None,
     ) -> Response:
         """Upload an image with a natural language query for analysis.
 
@@ -1000,6 +1031,8 @@ class LouieClient:
             share_mode: Visibility setting
             name: Optional thread name
             folder: Optional folder path for the thread (server support required)
+            session_trace_id: Optional session trace ID for distributed tracing
+                correlation when OpenTelemetry is not available.
 
         Returns:
             Response object with analysis results
@@ -1018,6 +1051,7 @@ class LouieClient:
             share_mode=share_mode,
             name=name,
             folder=folder,
+            session_trace_id=session_trace_id,
         )
 
     def upload_binary(
@@ -1032,6 +1066,7 @@ class LouieClient:
         name: str | None = None,
         folder: str | None = None,
         filename: str | None = None,
+        session_trace_id: str | None = None,
     ) -> Response:
         """Upload a binary file with a natural language query for analysis.
 
@@ -1045,6 +1080,8 @@ class LouieClient:
             name: Optional thread name
             folder: Optional folder path for the thread (server support required)
             filename: Optional filename to use
+            session_trace_id: Optional session trace ID for distributed tracing
+                correlation when OpenTelemetry is not available.
 
         Returns:
             Response object with analysis results
@@ -1064,6 +1101,7 @@ class LouieClient:
             name=name,
             folder=folder,
             filename=filename,
+            session_trace_id=session_trace_id,
         )
 
     def __enter__(self):

--- a/src/louieai/_tracing.py
+++ b/src/louieai/_tracing.py
@@ -1,0 +1,100 @@
+"""W3C Traceparent propagation for distributed tracing.
+
+This module provides traceparent header generation for correlating
+louie-py requests with distributed traces. It supports:
+
+1. OpenTelemetry integration: If OTel is configured with an active span,
+   the current trace context is automatically propagated.
+
+2. Session-level correlation: When OTel is not available, a session
+   trace_id is used to correlate all requests from a Cursor instance.
+
+The traceparent header follows the W3C Trace Context specification:
+https://www.w3.org/TR/trace-context/
+"""
+
+from __future__ import annotations
+
+import secrets
+
+
+def generate_trace_id() -> str:
+    """Generate a random 32-character hex trace ID."""
+    return secrets.token_hex(16)
+
+
+def generate_span_id() -> str:
+    """Generate a random 16-character hex span ID."""
+    return secrets.token_hex(8)
+
+
+def build_traceparent(trace_id: str, span_id: str, sampled: bool = True) -> str:
+    """Build a W3C traceparent header value.
+
+    Format: {version}-{trace_id}-{span_id}-{trace_flags}
+    Example: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+
+    Args:
+        trace_id: 32-character hex trace ID
+        span_id: 16-character hex span ID
+        sampled: Whether the trace is sampled (default True)
+
+    Returns:
+        W3C traceparent header value
+    """
+    flags = "01" if sampled else "00"
+    return f"00-{trace_id}-{span_id}-{flags}"
+
+
+def inject_otel_traceparent(headers: dict[str, str]) -> bool:
+    """Inject traceparent from OpenTelemetry context if available.
+
+    Uses the standard OTel propagate.inject() mechanism which handles
+    W3C Trace Context, baggage, and any configured propagators.
+
+    Args:
+        headers: Dict to inject traceparent into (modified in place)
+
+    Returns:
+        True if OTel context was injected, False otherwise
+    """
+    try:
+        from opentelemetry.propagate import inject
+        from opentelemetry.trace import INVALID_SPAN, get_current_span
+
+        span = get_current_span()
+        if span == INVALID_SPAN or not span.is_recording():
+            return False
+
+        inject(headers)
+        return True
+    except ImportError:
+        return False
+
+
+def get_traceparent(session_trace_id: str | None = None) -> str | None:
+    """Get traceparent header value for an outgoing request.
+
+    Priority:
+    1. Active OTel span context (if available)
+    2. Session trace_id with new span_id (if provided)
+    3. None (no tracing)
+
+    Args:
+        session_trace_id: Optional session-level trace ID for correlation
+            when OTel is not available
+
+    Returns:
+        traceparent header value or None
+    """
+    # Try OTel first
+    headers: dict[str, str] = {}
+    if inject_otel_traceparent(headers):
+        return headers.get("traceparent")
+
+    # Fallback to session trace
+    if session_trace_id:
+        span_id = generate_span_id()
+        return build_traceparent(session_trace_id, span_id)
+
+    return None

--- a/src/louieai/_upload.py
+++ b/src/louieai/_upload.py
@@ -50,6 +50,7 @@ class UploadClient:
         folder: str | None = None,
         parsing_options: dict[str, Any] | None = None,
         table_ai_overrides: TableAIOverrides | Mapping[str, Any] | None = None,
+        session_trace_id: str | None = None,
         **legacy_overrides: Any,
     ) -> Response:
         """Upload a DataFrame with a natural language query for analysis.
@@ -106,8 +107,8 @@ class UploadClient:
             ...     thread_id=response.thread_id
             ... )
         """
-        # Get headers with auth
-        headers = self._client._get_headers()
+        # Get headers with auth and tracing
+        headers = self._client._get_headers(session_trace_id=session_trace_id)
 
         # Serialize DataFrame to specified format
         file_data, filename, content_type = self._serialize_dataframe(df, format)
@@ -334,6 +335,7 @@ class UploadClient:
         share_mode: str = "Private",
         name: str | None = None,
         folder: str | None = None,
+        session_trace_id: str | None = None,
     ) -> Response:
         """Upload an image with a natural language query for analysis.
 
@@ -375,8 +377,8 @@ class UploadClient:
             ...     img_bytes = f.read()
             >>> response = client.upload_image("Extract text", img_bytes)
         """
-        # Get headers with auth
-        headers = self._client._get_headers()
+        # Get headers with auth and tracing
+        headers = self._client._get_headers(session_trace_id=session_trace_id)
 
         # Serialize image
         file_data, filename, content_type = self._serialize_image(image)
@@ -601,6 +603,7 @@ class UploadClient:
         name: str | None = None,
         folder: str | None = None,
         filename: str | None = None,
+        session_trace_id: str | None = None,
     ) -> Response:
         """Upload a binary file with a natural language query for analysis.
 
@@ -641,8 +644,8 @@ class UploadClient:
             ...     file_bytes = f.read()
             >>> response = client.upload_binary("Key points from this doc", file_bytes)
         """
-        # Get headers with auth
-        headers = self._client._get_headers()
+        # Get headers with auth and tracing
+        headers = self._client._get_headers(session_trace_id=session_trace_id)
 
         # Serialize binary file
         file_data, file_name, content_type = self._serialize_binary(file, filename)

--- a/src/louieai/notebook/cursor.py
+++ b/src/louieai/notebook/cursor.py
@@ -7,6 +7,7 @@ from typing import Any
 import pandas as pd
 
 from louieai._client import LouieClient, Response
+from louieai._tracing import generate_trace_id
 
 logger = logging.getLogger(__name__)
 
@@ -522,6 +523,7 @@ class Cursor:
         share_mode: str = "Private",
         name: str | None = None,
         folder: str | None = None,
+        _parent_trace_id: str | None = None,
     ):
         """Initialize global cursor.
 
@@ -531,6 +533,8 @@ class Cursor:
             name: Optional thread name (auto-generated from first message if not
                 provided)
             folder: Optional folder path for new threads (server support required)
+            _parent_trace_id: Internal parameter for inheriting trace context from
+                parent cursor. Do not use directly.
         """
         # Validate share_mode
         valid_modes = {"Private", "Organization", "Public"}
@@ -610,6 +614,8 @@ class Cursor:
         self._name: str | None = name
         self._folder: str | None = folder
         self._last_display_id: str | None = None
+        # Session-level trace ID for correlating requests when OTel is not available
+        self._trace_id: str = _parent_trace_id or generate_trace_id()
 
     def __call__(
         self,
@@ -819,6 +825,7 @@ class Cursor:
                     folder=self._folder,
                     format=kwargs.get("format", "parquet"),
                     parsing_options=kwargs.get("parsing_options"),
+                    session_trace_id=self._trace_id,
                 )
             elif actual_image is not None:
                 # Use upload_image for image queries
@@ -831,6 +838,7 @@ class Cursor:
                     share_mode=use_share_mode,
                     name=self._name,
                     folder=self._folder,
+                    session_trace_id=self._trace_id,
                 )
             elif actual_binary is not None:
                 # Use upload_binary for binary file queries
@@ -844,6 +852,7 @@ class Cursor:
                     name=self._name,
                     folder=self._folder,
                     filename=kwargs.get("filename"),
+                    session_trace_id=self._trace_id,
                 )
             elif self._in_jupyter() and self._last_display_id is None:
                 # Use streaming display for better UX (non-DataFrame queries)
@@ -858,6 +867,7 @@ class Cursor:
                     share_mode=use_share_mode,
                     name=self._name,
                     folder=self._folder,
+                    session_trace_id=self._trace_id,
                 )
 
                 # Create Response object from streaming result
@@ -876,6 +886,7 @@ class Cursor:
                     folder=self._folder,
                     traces=use_traces,
                     share_mode=use_share_mode,
+                    session_trace_id=self._trace_id,
                 )
 
             # Update thread ID in case it was created
@@ -1479,6 +1490,7 @@ class Cursor:
 
         # Create new Cursor with same client but fresh thread
         # The client instance contains all auth and configuration
+        # Pass parent trace_id so all cursors in same session share a trace
         if folder is None:
             folder = self._folder
 
@@ -1487,6 +1499,7 @@ class Cursor:
             share_mode=share_mode,
             name=name,
             folder=folder,
+            _parent_trace_id=self._trace_id,  # Share session trace for correlation
         )
 
     def _extract_dataframes(self, response: Response) -> list[pd.DataFrame]:

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -372,9 +372,10 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
     share_mode = kwargs.get("share_mode", "Private")
     name = kwargs.get("name")
     folder = kwargs.get("folder")
+    session_trace_id = kwargs.get("session_trace_id")
 
-    # Get headers
-    headers = client._get_headers()
+    # Get headers with tracing
+    headers = client._get_headers(session_trace_id=session_trace_id)
 
     # Build parameters
     params = {

--- a/tests/unit/test_table_ai_overrides.py
+++ b/tests/unit/test_table_ai_overrides.py
@@ -30,7 +30,9 @@ def mock_client(monkeypatch: pytest.MonkeyPatch) -> LouieClient:
     client = LouieClient(server_url="http://test")
     httpx_mock = MagicMock()
     client._client = httpx_mock  # type: ignore[attr-defined]
-    monkeypatch.setattr(client, "_get_headers", lambda: {})  # avoid auth
+    monkeypatch.setattr(
+        client, "_get_headers", lambda **kwargs: {}
+    )  # avoid auth, accept any kwargs
     monkeypatch.setattr(client, "_fetch_dataframe_arrow", lambda *args, **kwargs: None)
     return client
 
@@ -117,7 +119,7 @@ def test_upload_dataframe_with_table_ai_overrides(
 ) -> None:
     client = LouieClient(server_url="http://test")
     upload_client = UploadClient(client)
-    monkeypatch.setattr(client, "_get_headers", lambda: {})  # avoid auth
+    monkeypatch.setattr(client, "_get_headers", lambda **kwargs: {})  # avoid auth
 
     class FakeStreamResponse:
         def __init__(self) -> None:
@@ -196,7 +198,7 @@ def test_upload_dataframe_with_table_ai_overrides(
 def test_upload_dataframe_with_legacy_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
     client = LouieClient(server_url="http://test")
     upload_client = UploadClient(client)
-    monkeypatch.setattr(client, "_get_headers", lambda: {})
+    monkeypatch.setattr(client, "_get_headers", lambda **kwargs: {})
 
     class FakeStreamResponse:
         def __init__(self) -> None:

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,276 @@
+"""Unit tests for W3C traceparent propagation."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from louieai._tracing import (
+    build_traceparent,
+    generate_span_id,
+    generate_trace_id,
+    get_traceparent,
+    inject_otel_traceparent,
+)
+
+
+class TestGenerateTraceId:
+    """Tests for generate_trace_id."""
+
+    def test_returns_32_hex_chars(self) -> None:
+        """Trace ID should be 32 hex characters."""
+        trace_id = generate_trace_id()
+        assert len(trace_id) == 32
+        assert re.match(r"^[0-9a-f]{32}$", trace_id)
+
+    def test_returns_unique_values(self) -> None:
+        """Each call should return a unique trace ID."""
+        ids = {generate_trace_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestGenerateSpanId:
+    """Tests for generate_span_id."""
+
+    def test_returns_16_hex_chars(self) -> None:
+        """Span ID should be 16 hex characters."""
+        span_id = generate_span_id()
+        assert len(span_id) == 16
+        assert re.match(r"^[0-9a-f]{16}$", span_id)
+
+    def test_returns_unique_values(self) -> None:
+        """Each call should return a unique span ID."""
+        ids = {generate_span_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestBuildTraceparent:
+    """Tests for build_traceparent."""
+
+    def test_w3c_format(self) -> None:
+        """Traceparent should follow W3C format."""
+        trace_id = "0af7651916cd43dd8448eb211c80319c"
+        span_id = "b7ad6b7169203331"
+        tp = build_traceparent(trace_id, span_id)
+        assert tp == "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+    def test_sampled_flag(self) -> None:
+        """Sampled flag should be 01 when True, 00 when False."""
+        trace_id = "0af7651916cd43dd8448eb211c80319c"
+        span_id = "b7ad6b7169203331"
+
+        tp_sampled = build_traceparent(trace_id, span_id, sampled=True)
+        assert tp_sampled.endswith("-01")
+
+        tp_not_sampled = build_traceparent(trace_id, span_id, sampled=False)
+        assert tp_not_sampled.endswith("-00")
+
+
+class TestInjectOtelTraceparent:
+    """Tests for inject_otel_traceparent."""
+
+    def test_returns_false_when_otel_not_installed(self) -> None:
+        """Should return False when opentelemetry is not available."""
+        with patch.dict("sys.modules", {"opentelemetry": None}):
+            # Force reimport to trigger ImportError
+            headers: dict[str, str] = {}
+            # The function catches ImportError internally
+            result = inject_otel_traceparent(headers)
+            # May return True if otel is installed in test env
+            # Just verify it doesn't raise
+            assert isinstance(result, bool)
+
+    def test_returns_false_when_no_active_span(self) -> None:
+        """Should return False when no span is active."""
+        try:
+            from opentelemetry.trace import INVALID_SPAN
+
+            with patch(
+                "opentelemetry.trace.get_current_span", return_value=INVALID_SPAN
+            ):
+                headers: dict[str, str] = {}
+                result = inject_otel_traceparent(headers)
+                assert result is False
+                assert "traceparent" not in headers
+        except ImportError:
+            pytest.skip("opentelemetry not installed")
+
+    def test_injects_traceparent_when_span_active(self) -> None:
+        """Should inject traceparent when an active span exists."""
+        try:
+            from opentelemetry.sdk.trace import TracerProvider
+
+            # Set up a real tracer
+            provider = TracerProvider()
+            tracer = provider.get_tracer("test")
+
+            with tracer.start_as_current_span("test_span"):
+                headers: dict[str, str] = {}
+                result = inject_otel_traceparent(headers)
+                assert result is True
+                assert "traceparent" in headers
+                # Verify format: 00-{trace_id}-{span_id}-{flags}
+                assert re.match(
+                    r"^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$", headers["traceparent"]
+                )
+        except ImportError:
+            pytest.skip("opentelemetry-sdk not installed")
+
+
+class TestGetTraceparent:
+    """Tests for get_traceparent."""
+
+    def test_returns_none_without_otel_or_session(self) -> None:
+        """Should return None when no OTel and no session trace."""
+        with patch("louieai._tracing.inject_otel_traceparent", return_value=False):
+            result = get_traceparent()
+            assert result is None
+
+    def test_returns_session_trace_when_no_otel(self) -> None:
+        """Should use session trace when OTel is not available."""
+        with patch("louieai._tracing.inject_otel_traceparent", return_value=False):
+            session_trace_id = "abcd1234abcd1234abcd1234abcd1234"
+            result = get_traceparent(session_trace_id)
+
+            assert result is not None
+            assert result.startswith(f"00-{session_trace_id}-")
+            assert result.endswith("-01")
+            # Verify format
+            assert re.match(r"^00-[0-9a-f]{32}-[0-9a-f]{16}-01$", result)
+
+    def test_prefers_otel_over_session(self) -> None:
+        """Should prefer OTel context over session trace."""
+        otel_traceparent = "00-otel1234otel1234otel1234otel1234-otelspan12345678-01"
+
+        def mock_inject(headers: dict[str, str]) -> bool:
+            headers["traceparent"] = otel_traceparent
+            return True
+
+        with patch("louieai._tracing.inject_otel_traceparent", side_effect=mock_inject):
+            session_trace_id = "sess1234sess1234sess1234sess1234"
+            result = get_traceparent(session_trace_id)
+
+            # Should return OTel traceparent, not session
+            assert result == otel_traceparent
+
+    def test_generates_new_span_id_each_call(self) -> None:
+        """Each call should generate a new span ID."""
+        with patch("louieai._tracing.inject_otel_traceparent", return_value=False):
+            session_trace_id = "abcd1234abcd1234abcd1234abcd1234"
+
+            results = [get_traceparent(session_trace_id) for _ in range(10)]
+
+            # All should have same trace_id
+            trace_ids = [r.split("-")[1] for r in results if r]  # type: ignore[union-attr]
+            assert all(tid == session_trace_id for tid in trace_ids)
+
+            # All should have different span_ids
+            span_ids = [r.split("-")[2] for r in results if r]  # type: ignore[union-attr]
+            assert len(set(span_ids)) == 10
+
+
+class TestClientHeadersIntegration:
+    """Integration tests for traceparent in client headers."""
+
+    def test_get_headers_without_tracing(self) -> None:
+        """Headers should work without any tracing context."""
+        from louieai._client import LouieClient
+
+        # Mock the auth manager
+        with patch.object(LouieClient, "__init__", lambda self: None):
+            client = LouieClient.__new__(LouieClient)
+            client._auth_manager = MagicMock()
+            client._auth_manager.get_token.return_value = "test-token"
+            client._auth_manager._credentials = {}
+
+            with patch("louieai._tracing.get_traceparent", return_value=None):
+                headers = client._get_headers()
+
+            assert "Authorization" in headers
+            assert "traceparent" not in headers
+
+    def test_get_headers_with_session_trace(self) -> None:
+        """Headers should include traceparent from session trace."""
+        from louieai._client import LouieClient
+
+        with patch.object(LouieClient, "__init__", lambda self: None):
+            client = LouieClient.__new__(LouieClient)
+            client._auth_manager = MagicMock()
+            client._auth_manager.get_token.return_value = "test-token"
+            client._auth_manager._credentials = {}
+
+            session_trace = "abcd1234abcd1234abcd1234abcd1234"
+            headers = client._get_headers(session_trace_id=session_trace)
+
+            assert "Authorization" in headers
+            assert "traceparent" in headers
+            assert headers["traceparent"].startswith(f"00-{session_trace}-")
+
+    def test_get_headers_with_explicit_traceparent(self) -> None:
+        """Explicit traceparent should override auto-generated."""
+        from louieai._client import LouieClient
+
+        with patch.object(LouieClient, "__init__", lambda self: None):
+            client = LouieClient.__new__(LouieClient)
+            client._auth_manager = MagicMock()
+            client._auth_manager.get_token.return_value = "test-token"
+            client._auth_manager._credentials = {}
+
+            explicit_tp = "00-explicit1234explicit1234explic-explicitspan1234-01"
+            headers = client._get_headers(
+                session_trace_id="should-be-ignored",
+                traceparent=explicit_tp,
+            )
+
+            assert headers["traceparent"] == explicit_tp
+
+
+class TestCursorSessionTrace:
+    """Tests for Cursor session trace management."""
+
+    def test_cursor_generates_trace_id(self) -> None:
+        """Cursor should generate a session trace ID on init."""
+        from collections import deque
+
+        from louieai.notebook.cursor import Cursor
+
+        # Create cursor without calling __init__
+        cursor = Cursor.__new__(Cursor)
+        cursor._client = MagicMock()
+        cursor._history = deque(maxlen=100)
+        cursor._current_thread = None
+        cursor._traces = False
+        cursor._share_mode = "Private"
+        cursor._name = None
+        cursor._folder = None
+        cursor._last_display_id = None
+        cursor._trace_id = generate_trace_id()
+
+        assert len(cursor._trace_id) == 32
+        assert re.match(r"^[0-9a-f]{32}$", cursor._trace_id)
+
+    def test_cursor_new_inherits_trace_id(self) -> None:
+        """Cursor.new() should inherit parent's trace ID."""
+        from collections import deque
+
+        from louieai.notebook.cursor import Cursor
+
+        # Create parent cursor without calling __init__
+        parent = Cursor.__new__(Cursor)
+        parent._client = MagicMock()
+        parent._history = deque(maxlen=100)
+        parent._current_thread = None
+        parent._traces = False
+        parent._share_mode = "Private"
+        parent._name = None
+        parent._folder = None
+        parent._last_display_id = None
+        parent._trace_id = "parent123parent123parent123parent1"
+
+        # Create child via new()
+        child = parent.new()
+
+        # Child should share parent's trace_id
+        assert child._trace_id == parent._trace_id

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -200,6 +200,7 @@ class TestLouieClientUpload:
             name=None,
             folder=None,
             parsing_options=None,
+            session_trace_id=None,
         )
         assert response == mock_response
 

--- a/tests/unit/test_upload_edge_cases.py
+++ b/tests/unit/test_upload_edge_cases.py
@@ -233,6 +233,7 @@ class TestLouieClientMethods:
                 name="Custom Name",
                 folder=None,
                 parsing_options={"delimiter": ";"},
+                session_trace_id=None,
             )
             assert result == mock_response
 
@@ -258,6 +259,7 @@ class TestLouieClientMethods:
                 share_mode="Private",
                 name=None,
                 folder=None,
+                session_trace_id=None,
             )
 
             # Test binary upload with thread_id
@@ -272,4 +274,5 @@ class TestLouieClientMethods:
                 name=None,
                 folder=None,
                 filename=None,
+                session_trace_id=None,
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -572,6 +572,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -796,6 +808,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mypy" },
     { name = "nbclient" },
+    { name = "opentelemetry-api" },
     { name = "pre-commit" },
     { name = "pyarrow-stubs" },
     { name = "pytest" },
@@ -830,6 +843,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.0" },
     { name = "nbclient", marker = "extra == 'dev'", specifier = ">=0.10.2" },
     { name = "nbclient", marker = "extra == 'docs'", specifier = ">=0.10.2" },
+    { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
@@ -1382,6 +1396,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/c9/142c1e03f199d202da8e980c2496213509291b6024fd2735ad28ae7065c7/numpy-2.3.2-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446acd11fe3dc1830568c941d44449fd5cb83068e5c70bd5a470d323d448296", size = 14419651, upload-time = "2025-07-24T20:58:59.048Z" },
     { url = "https://files.pythonhosted.org/packages/8b/95/8023e87cbea31a750a6c00ff9427d65ebc5fef104a136bfa69f76266d614/numpy-2.3.2-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa098a5ab53fa407fded5870865c6275a5cd4101cfdef8d6fafc48286a96e981", size = 16760166, upload-time = "2025-07-24T21:28:56.38Z" },
     { url = "https://files.pythonhosted.org/packages/78/e3/6690b3f85a05506733c7e90b577e4762517404ea78bab2ca3a5cb1aeb78d/numpy-2.3.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6936aff90dda378c09bea075af0d9c675fe3a977a9d2402f95a87f440f59f619", size = 12977811, upload-time = "2025-07-24T21:29:18.234Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
 ]
 
 [[package]]
@@ -2386,4 +2413,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
## Summary

- Add `_tracing.py` module with W3C traceparent generation helpers
- Cursor generates session `trace_id`, shared across `new()` children for session correlation
- `LouieClient._get_headers()` injects traceparent into all HTTP requests
- Priority: OTel context > session trace > none (no tracing)
- Add `opentelemetry-api` to dev deps for type checking

## How it works

**Session-level correlation** (without OTel):
```python
lui = louieai.Cursor()
lui("query 1")  # traceparent: 00-{session_trace}-{span1}-01
lui("query 2")  # traceparent: 00-{session_trace}-{span2}-01

child = lui.new()
child("query 3")  # traceparent: 00-{session_trace}-{span3}-01 (same trace!)
```

**OTel integration** (when available):
```python
with tracer.start_span("my_analysis"):
    lui("query")  # Uses OTel's active span context automatically
```

## Trace example (louie-py client ↔ server)

Local test against desktop-slim with an explicit session trace id:
```
$ PYTHONPATH=/home/lmeyerov/Work/louie-py/src \
  uv run python /tmp/louie_py_trace_test.py
trace_id 11111111111111111111111111111111
thread_id D_wDID8DiCeqYKi58wJ4kD

$ bin/otel/cmds/trace2tree 11111111111111111111111111111111
fastapi_proxy_POST_/api/chat/ [7730.66ms]
  api_request_POST_/api/chat/ [7730.45ms]
    api_run [7197.16ms]
      LLM [...]
```

## Test plan

- [x] Unit tests for tracing module (17 tests)
- [x] All existing unit tests pass (470 passed)
- [x] Ruff and mypy pass
- [x] Local trace correlation verified with desktop-slim + `bin/otel/cmds/trace2tree` (example above)

Closes #35
