### PR TITLE
Support pandas 2.x and 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,53 @@ jobs:
           name: Unit Tests
           fail_ci_if_error: false  # Don't fail if Codecov is down
 
+  # Stage 3b: Targeted pandas version checks
+  unit-tests-pandas2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [quality-checks, light-smoke-test]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          uv venv --python python3.10
+          uv pip install -e ".[dev]"
+          uv pip install "pandas>=2,<3"
+      - name: Run unit tests
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/unit/ -v
+
+  unit-tests-pandas3:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [quality-checks, light-smoke-test]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          uv venv --python python3.13
+          uv pip install -e ".[dev]"
+          uv pip install "pandas>=3,<4"
+      - name: Run unit tests
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/unit/ -v
+
   # Stage 4: Integration tests (conditional on credentials)
   integration-tests:
     runs-on: ubuntu-latest
@@ -226,7 +273,7 @@ jobs:
   # Final summary job (for branch protection rules)
   ci-success:
     runs-on: ubuntu-latest
-    needs: [quality-checks, light-smoke-test, unit-tests, docs-test, install-test]
+    needs: [quality-checks, light-smoke-test, unit-tests, unit-tests-pandas2, unit-tests-pandas3, docs-test, install-test]
     # Note: integration-tests is not required since it's conditional
     if: always()
     steps:
@@ -234,6 +281,8 @@ jobs:
         run: |
           if [[ "${{ needs.quality-checks.result }}" != "success" || \
                 "${{ needs.unit-tests.result }}" != "success" || \
+                "${{ needs.unit-tests-pandas2.result }}" != "success" || \
+                "${{ needs.unit-tests-pandas3.result }}" != "success" || \
                 "${{ needs.docs-test.result }}" != "success" || \
                 "${{ needs.install-test.result }}" != "success" ]]; then
             echo "❌ One or more required jobs failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,47 +95,34 @@ jobs:
           fail_ci_if_error: false  # Don't fail if Codecov is down
 
   # Stage 3b: Targeted pandas version checks
-  unit-tests-pandas2:
+  unit-tests-pandas-compat:
+    name: unit-tests-pandas (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [quality-checks, light-smoke-test]
+    strategy:
+      matrix:
+        include:
+          - name: pandas2-py310
+            python-version: "3.10"
+            pandas-version: "pandas>=2,<3"
+          - name: pandas3-py313
+            python-version: "3.13"
+            pandas-version: "pandas>=3,<4"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
-          uv venv --python python3.10
+          uv venv --python python${{ matrix.python-version }}
           uv pip install -e ".[dev]"
-          uv pip install "pandas>=2,<3"
-      - name: Run unit tests
-        run: |
-          source .venv/bin/activate
-          python -m pytest tests/unit/ -v
-
-  unit-tests-pandas3:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [quality-checks, light-smoke-test]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.13"
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Install dependencies
-        run: |
-          uv venv --python python3.13
-          uv pip install -e ".[dev]"
-          uv pip install "pandas>=3,<4"
+          uv pip install "${{ matrix.pandas-version }}"
       - name: Run unit tests
         run: |
           source .venv/bin/activate
@@ -273,7 +260,7 @@ jobs:
   # Final summary job (for branch protection rules)
   ci-success:
     runs-on: ubuntu-latest
-    needs: [quality-checks, light-smoke-test, unit-tests, unit-tests-pandas2, unit-tests-pandas3, docs-test, install-test]
+    needs: [quality-checks, light-smoke-test, unit-tests, unit-tests-pandas-compat, docs-test, install-test]
     # Note: integration-tests is not required since it's conditional
     if: always()
     steps:
@@ -281,8 +268,7 @@ jobs:
         run: |
           if [[ "${{ needs.quality-checks.result }}" != "success" || \
                 "${{ needs.unit-tests.result }}" != "success" || \
-                "${{ needs.unit-tests-pandas2.result }}" != "success" || \
-                "${{ needs.unit-tests-pandas3.result }}" != "success" || \
+                "${{ needs.unit-tests-pandas-compat.result }}" != "success" || \
                 "${{ needs.docs-test.result }}" != "success" || \
                 "${{ needs.install-test.result }}" != "success" ]]; then
             echo "❌ One or more required jobs failed"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,6 +132,25 @@
       ]
     }
   ],
-  "results": {},
-  "generated_at": "2026-01-16T23:24:34Z"
+  "results": {
+    "docs/index.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/index.md",
+        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "tests/integration/notebook/test_cursor_new_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/notebook/test_cursor_new_integration.py",
+        "hashed_secret": "3c1046153e46b813c467bcb0b73680035cc0f722",
+        "is_verified": false,
+        "line_number": 57
+      }
+    ]
+  },
+  "generated_at": "2026-01-25T06:11:40Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - None.
 
+## [0.7.1] - 2026-01-25
+
+### Added
+- Targeted pandas 2.x/3.x compatibility tests in CI.
+
+### Changed
+- pandas requirement updated to `>=2,<4` (supports 2.x and 3.x).
+- Dropped direct `pytz` dependency; now only transitive via pandas 2.x.
+
+### Fixed
+- Secret detection CI no longer rewrites `.secrets.baseline` on check-only runs.
+
 ## [0.7.0] - 2026-01-16
 
 ### Added

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,8 +6,6 @@ Get up and running with LouieAI in minutes using the notebook-friendly API.
 
 See the [Installation Guide](installation.md) if you haven't installed LouieAI yet.
 
-LouieAI supports pandas 2.x and 3.x (installed automatically as a dependency).
-
 ## 2. Set Up Authentication
 
 Set your Graphistry credentials as environment variables:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,6 +6,8 @@ Get up and running with LouieAI in minutes using the notebook-friendly API.
 
 See the [Installation Guide](installation.md) if you haven't installed LouieAI yet.
 
+LouieAI supports pandas 2.x and 3.x (installed automatically as a dependency).
+
 ## 2. Set Up Authentication
 
 Set your Graphistry credentials as environment variables:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,8 @@ Welcome to the **LouieAI** Python client library documentation.
 pip install louieai
 ```
 
+LouieAI supports pandas 2.x and 3.x (installed automatically as a dependency).
+
 ```python
 import graphistry
 import louieai

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,6 @@ Welcome to the **LouieAI** Python client library documentation.
 pip install louieai
 ```
 
-LouieAI supports pandas 2.x and 3.x (installed automatically as a dependency).
-
 ```python
 import graphistry
 import louieai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ["Louie.ai", "Graphistry", "AI", "client", "investigation"]
 dependencies = [
   "graphistry>=0.41.0",
   "httpx>=0.28.0",
-  "pandas>=2.0.0",
+  "pandas>=2.0.0,<4",
   "pillow>=11.3.0",
   "pyarrow>=14.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "graphistry>=0.41.0",
   "httpx>=0.28.0",
   "pandas>=2.0.0,<4",
-  "pytz>=2024.1",
   "pillow>=11.3.0",
   "pyarrow>=14.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "graphistry>=0.41.0",
   "httpx>=0.28.0",
   "pandas>=2.0.0,<4",
+  "pytz>=2024.1",
   "pillow>=11.3.0",
   "pyarrow>=14.0.0",
 ]

--- a/scripts/ci/secret-detection.sh
+++ b/scripts/ci/secret-detection.sh
@@ -65,37 +65,42 @@ if [ "$CHECK_ONLY" == true ]; then
     # Pre-commit mode: just check for new secrets
     echo "🔍 Checking for secrets in staged files..."
     
-    # Get list of staged files (excluding plans/ and tmp/)
-    STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v '^plans/' | grep -v '^tmp/' || true)
+    # Get list of staged files (excluding plans/, tmp/, and the baseline itself)
+    STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM \
+        | grep -v '^plans/' \
+        | grep -v '^tmp/' \
+        | grep -v '^\.secrets\.baseline$' \
+        || true)
     
     if [ -z "$STAGED_FILES" ]; then
         print_success "No files to check"
         exit 0
     fi
     
-    # Check staged files for secrets
+    # Check staged files for secrets using a temp baseline to avoid mutating the real one
     TEMP_BASELINE=$(mktemp)
-    echo "$STAGED_FILES" | xargs $DETECT_SECRETS scan --baseline .secrets.baseline > "$TEMP_BASELINE" 2>/dev/null || true
+    TEMP_SCAN=$(mktemp)
+    cp .secrets.baseline "$TEMP_BASELINE"
+    echo "$STAGED_FILES" | xargs $DETECT_SECRETS scan --baseline "$TEMP_BASELINE" > "$TEMP_SCAN" 2>/dev/null || true
     
     # Check if any new secrets were detected
-    if [ -s "$TEMP_BASELINE" ]; then
+    if [ -s "$TEMP_SCAN" ]; then
         NEW_SECRETS=$(python3 -c "
 import json
 import sys
-with open('$TEMP_BASELINE') as f:
+with open('$TEMP_SCAN') as f:
     data = json.load(f)
     total = sum(len(secrets) for secrets in data.get('results', {}).values())
     sys.exit(0 if total == 0 else 1)
 " 2>/dev/null || echo "1")
-        
-        rm "$TEMP_BASELINE"
-        
+        rm -f "$TEMP_SCAN" "$TEMP_BASELINE"
+
         if [ "$NEW_SECRETS" == "1" ]; then
             print_error "New secrets detected! Use clear placeholders like 'sk-XXXXXXXX' or '<your-password>'"
         fi
     fi
     
-    rm -f "$TEMP_BASELINE"
+    rm -f "$TEMP_SCAN" "$TEMP_BASELINE"
     print_success "No secrets detected"
 else
     # CI mode: full scan

--- a/tests/integration/notebook/test_cursor_new_integration.py
+++ b/tests/integration/notebook/test_cursor_new_integration.py
@@ -137,10 +137,12 @@ class TestCursorNewIntegration:
                 share_mode="Private",
                 name="Run analysis",
                 folder=None,
+                session_trace_id=parent._trace_id,
             )
 
         # Create new cursor with different share_mode
         child = parent.new(share_mode="Organization")
+        assert child._trace_id == parent._trace_id
 
         # Test streaming with new cursor
         with (
@@ -164,6 +166,7 @@ class TestCursorNewIntegration:
                 share_mode="Organization",  # Inherited from new()
                 name="New analysis",
                 folder=None,
+                session_trace_id=child._trace_id,
             )
 
     def test_error_handling_preserved_in_new(self):

--- a/uv.lock
+++ b/uv.lock
@@ -796,7 +796,6 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "pyarrow" },
-    { name = "pytz" },
 ]
 
 [package.optional-dependencies]
@@ -854,7 +853,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytz", specifier = ">=2024.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev", "docs"]

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "graphistry"
-version = "0.41.0"
+version = "0.50.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -499,9 +499,9 @@ dependencies = [
     { name = "squarify" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/af/8c5399d77351e4767a4e5bd268eb6828ae20d01a6cbc4caac4484a13739e/graphistry-0.41.0.tar.gz", hash = "sha256:a56d790b5251b0a9eb715b641ea9717b79d8589b9ff8e86e922ffcee67ba891d", size = 308164, upload-time = "2025-07-26T16:15:09.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/96/38eeef45d1e16e3f1b9ee7876e96a1b2fd28564023afda45b0ac9fa9c666/graphistry-0.50.5.tar.gz", hash = "sha256:480e418a0eb5da75b9218c2e5729f48a01622ea7a3241ca9cecef416dd2c7c6a", size = 403937, upload-time = "2026-01-25T23:05:55.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/61/a24176a2b92baab083f92c8bcd334b6ba19f1abee78d203eb8d53ad4eacf/graphistry-0.41.0-py3-none-any.whl", hash = "sha256:e274863c1c0a779512d5292f6b89f958e882a4b04d61061c495cc020d7b2bb77", size = 332422, upload-time = "2025-07-26T16:15:07.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/03/f60c59ad6744bd3433ba710beb6b466676c76a521f32391975e7ca51e610/graphistry-0.50.5-py3-none-any.whl", hash = "sha256:82ab666031ee5632cbe78b67a888c00a16fac6a8d4475b4ffc8ac067078420b9", size = 439800, upload-time = "2026-01-25T23:05:53.204Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -844,7 +844,7 @@ requires-dist = [
     { name = "nbclient", marker = "extra == 'dev'", specifier = ">=0.10.2" },
     { name = "nbclient", marker = "extra == 'docs'", specifier = ">=0.10.2" },
     { name = "opentelemetry-api", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pandas", specifier = ">=2.0.0,<4" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -796,6 +796,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "pyarrow" },
+    { name = "pytz" },
 ]
 
 [package.optional-dependencies]
@@ -853,6 +854,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytz", specifier = ">=2024.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev", "docs"]


### PR DESCRIPTION
## Summary
- Explicitly support pandas 2.x/3.x in deps and docs, with targeted CI coverage (no full cross-product)
- Align streaming integration test with session trace correlation behavior
- Fix detect-secrets pre-commit check to avoid mutating the baseline; update baseline for placeholder hits

## Testing
- ./scripts/ci-quick.sh