### PR TITLE
fix: use client timeouts in notebook streaming, add logging

### DIFF
--- a/src/louieai/__init__.py
+++ b/src/louieai/__init__.py
@@ -10,6 +10,7 @@ except ImportError:
 
 from ._client import Response, Thread
 from ._table_ai import TableAIOverrides
+from ._types import ShareMode, UserAgent
 from .notebook import Cursor
 
 
@@ -82,7 +83,7 @@ def _extract_org_name_from_graphistry(graphistry_client) -> str | None:
 
 def louie(
     graphistry_client: Any | None = None,
-    share_mode: str = "Private",
+    share_mode: ShareMode = "Private",
     name: str | None = None,
     folder: str | None = None,
     **kwargs: Any,
@@ -207,8 +208,10 @@ def louie(
 __all__ = [
     "Cursor",
     "Response",
+    "ShareMode",
     "TableAIOverrides",
     "Thread",
+    "UserAgent",
     "__version__",
     "louie",
 ]

--- a/src/louieai/_client.py
+++ b/src/louieai/_client.py
@@ -9,6 +9,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
+from louieai._types import ShareMode, UserAgent
+
 import httpx
 import pandas as pd
 import pyarrow as pa
@@ -657,7 +659,8 @@ class LouieClient:
         name: str | None = None,
         folder: str | None = None,
         traces: bool = False,
-        share_mode: str = "Private",
+        share_mode: ShareMode = "Private",
+        user_agent: UserAgent = "API",
         table_ai_overrides: TableAIOverrides | Mapping[str, Any] | None = None,
         use_batch: bool | None = None,
         session_trace_id: str | None = None,
@@ -673,6 +676,7 @@ class LouieClient:
             folder: Optional folder path (applied only when creating a new thread)
             traces: Whether to include reasoning traces in response (default: False)
             share_mode: Visibility mode - "Private", "Organization", or "Public"
+            user_agent: DataThread creation_user_agent — "API" or "Louie"
             table_ai_overrides: Structured overrides via dataclass or mapping.
             use_batch: Force singleshot (`True`) or streaming (`False`); defaults to
                 singleshot when overrides are provided.
@@ -693,6 +697,7 @@ class LouieClient:
             # Convert bool to string for HTTP params
             "ignore_traces": str(not traces).lower(),
             "share_mode": share_mode,
+            "user_agent": user_agent,
         }
 
         # Add thread ID if continuing existing thread

--- a/src/louieai/_client.py
+++ b/src/louieai/_client.py
@@ -548,6 +548,15 @@ class LouieClient:
 
         for elem in elements:
             if elem.get("type") in ["DfElement", "df", "DataFrame", "dataframe"]:
+                # Skip empty DataFrames — server may GC them before fetch
+                meta = elem.get("metadata", {})
+                shape = meta.get("shape", [])
+                if shape and shape[0] == 0:
+                    logger.debug(
+                        "Skipping empty DF %s (shape=%s)", elem.get("id"), shape
+                    )
+                    continue
+
                 df_id = (
                     elem.get("df_id")
                     or elem.get("block_id")

--- a/src/louieai/_client.py
+++ b/src/louieai/_client.py
@@ -613,7 +613,7 @@ class LouieClient:
         *,
         agent: str = "LouieAgent",
         traces: bool = False,
-        share_mode: str = "Private",
+        share_mode: ShareMode = "Private",
         table_ai_overrides: TableAIOverrides | Mapping[str, Any] | None = None,
         **override_kwargs: Any,
     ) -> Thread:
@@ -828,7 +828,7 @@ class LouieClient:
         thread_id: str | None = None,
         traces: bool = False,
         agent: str = "LouieAgent",
-        share_mode: str = "Private",
+        share_mode: ShareMode = "Private",
         **kwargs: Any,
     ) -> Response:
         """Make the client callable for ergonomic usage.

--- a/src/louieai/_client.py
+++ b/src/louieai/_client.py
@@ -547,13 +547,10 @@ class LouieClient:
 
         for elem in elements:
             if elem.get("type") in ["DfElement", "df", "DataFrame", "dataframe"]:
-                # Skip empty DataFrames — server may GC them before fetch
-                meta = elem.get("metadata", {})
-                shape = meta.get("shape", [])
+                # Workaround: server GCs empty DFs before fetch (#40)
+                shape = (elem.get("metadata") or {}).get("shape", [])
                 if shape and shape[0] == 0:
-                    logger.debug(
-                        "Skipping empty DF %s (shape=%s)", elem.get("id"), shape
-                    )
+                    elem["table"] = pd.DataFrame()
                     continue
 
                 df_id = (

--- a/src/louieai/_client.py
+++ b/src/louieai/_client.py
@@ -9,8 +9,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
-from louieai._types import ShareMode, UserAgent
-
 import httpx
 import pandas as pd
 import pyarrow as pa
@@ -21,6 +19,7 @@ from ._table_ai import (
     normalize_table_ai_overrides,
 )
 from ._tracing import get_traceparent
+from ._types import ShareMode, UserAgent
 from .auth import AuthManager, auto_retry_auth
 
 logger = logging.getLogger(__name__)

--- a/src/louieai/_types.py
+++ b/src/louieai/_types.py
@@ -1,0 +1,6 @@
+"""Shared type aliases matching the Louie server models."""
+
+from typing import Literal
+
+ShareMode = Literal["Public", "Private", "Organization"]
+UserAgent = Literal["API", "Louie"]

--- a/src/louieai/notebook/cursor.py
+++ b/src/louieai/notebook/cursor.py
@@ -618,10 +618,10 @@ class Cursor:
         self._history: deque[Response] = deque(maxlen=100)
         self._current_thread: str | None = None
         self._traces: bool = False
-        self._share_mode: str = share_mode
+        self._share_mode: ShareMode = share_mode
         self._name: str | None = name
         self._folder: str | None = folder
-        self._user_agent: str = user_agent
+        self._user_agent: UserAgent = user_agent
         self._frontend_url: str | None = frontend_url
         self._last_display_id: str | None = None
         # Session-level trace ID for correlating requests when OTel is not available
@@ -633,7 +633,7 @@ class Cursor:
         df: pd.DataFrame | None = None,
         *,
         traces: bool | None = None,
-        share_mode: str | None = None,
+        share_mode: ShareMode | None = None,
         **kwargs: Any,
     ) -> "Cursor":
         """Execute a query with implicit thread management and optional DataFrame.
@@ -1463,7 +1463,7 @@ class Cursor:
 
     def new(
         self,
-        share_mode: str | None = None,
+        share_mode: ShareMode | None = None,
         name: str | None = None,
         folder: str | None = None,
     ) -> "Cursor":

--- a/src/louieai/notebook/cursor.py
+++ b/src/louieai/notebook/cursor.py
@@ -525,6 +525,7 @@ class Cursor:
         name: str | None = None,
         folder: str | None = None,
         user_agent: UserAgent = "API",
+        frontend_url: str | None = None,
         _parent_trace_id: str | None = None,
     ):
         """Initialize global cursor.
@@ -536,6 +537,9 @@ class Cursor:
                 provided)
             folder: Optional folder path for new threads (server support required)
             user_agent: DataThread creation_user_agent — "API" or "Louie"
+            frontend_url: Base URL for thread links. Auto-detected if not set:
+                desktop (localhost) uses ``louie://n/`` deep links,
+                team servers use ``server_url``.
             _parent_trace_id: Internal parameter for inheriting trace context from
                 parent cursor. Do not use directly.
         """
@@ -617,6 +621,7 @@ class Cursor:
         self._name: str | None = name
         self._folder: str | None = folder
         self._user_agent: str = user_agent
+        self._frontend_url: str | None = frontend_url
         self._last_display_id: str | None = None
         # Session-level trace ID for correlating requests when OTel is not available
         self._trace_id: str = _parent_trace_id or generate_trace_id()
@@ -974,9 +979,9 @@ class Cursor:
     def url(self) -> str | None:
         """Get the URL for the current thread.
 
-        Returns a shareable URL that opens the current conversation thread
-        in the Louie web interface. Useful for sharing analysis results
-        with team members or bookmarking conversations.
+        Returns a link that opens the current conversation thread.
+        Desktop servers (localhost) produce ``louie://`` deep links;
+        team servers produce web URLs. Override with ``frontend_url``.
 
         Returns:
             str | None: The thread URL if a thread exists, None otherwise.
@@ -988,8 +993,13 @@ class Cursor:
         """
         if not self._current_thread:
             return None
-        base_url = self._client.server_url.rstrip("/")
-        return f"{base_url}/?dthread={self._current_thread}"
+        if self._frontend_url is not None:
+            base = self._frontend_url.rstrip("/")
+            return f"{base}/?dthread={self._current_thread}"
+        server = self._client.server_url
+        if "localhost" in server or "127.0.0.1" in server:
+            return f"louie://n/{self._current_thread}"
+        return f"{server.rstrip('/')}/?dthread={self._current_thread}"
 
     @property
     def df(self) -> pd.DataFrame | None:

--- a/src/louieai/notebook/cursor.py
+++ b/src/louieai/notebook/cursor.py
@@ -537,9 +537,10 @@ class Cursor:
                 provided)
             folder: Optional folder path for new threads (server support required)
             user_agent: DataThread creation_user_agent — "API" or "Louie"
-            frontend_url: Base URL for thread links. Auto-detected if not set:
-                desktop (localhost) uses ``louie://n/`` deep links,
-                team servers use ``server_url``.
+            frontend_url: Override base URL for thread links. Auto-detected
+                if not set: localhost → ``louie://n/`` deep links, remote →
+                ``server_url``. Devs running a team server on localhost can
+                pass e.g. ``frontend_url="http://localhost:5173"``.
             _parent_trace_id: Internal parameter for inheriting trace context from
                 parent cursor. Do not use directly.
         """
@@ -993,9 +994,13 @@ class Cursor:
         """
         if not self._current_thread:
             return None
+        # Explicit override (e.g., devs running a team server on localhost)
         if self._frontend_url is not None:
             base = self._frontend_url.rstrip("/")
+            if base.startswith("louie://"):
+                return f"{base}/{self._current_thread}"
             return f"{base}/?dthread={self._current_thread}"
+        # Auto-detect: localhost → desktop deep link, otherwise web URL
         server = self._client.server_url
         if "localhost" in server or "127.0.0.1" in server:
             return f"louie://n/{self._current_thread}"

--- a/src/louieai/notebook/cursor.py
+++ b/src/louieai/notebook/cursor.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from louieai._client import LouieClient, Response
 from louieai._tracing import generate_trace_id
+from louieai._types import ShareMode, UserAgent
 
 logger = logging.getLogger(__name__)
 
@@ -520,9 +521,10 @@ class Cursor:
     def __init__(
         self,
         client: LouieClient | None = None,
-        share_mode: str = "Private",
+        share_mode: ShareMode = "Private",
         name: str | None = None,
         folder: str | None = None,
+        user_agent: UserAgent = "API",
         _parent_trace_id: str | None = None,
     ):
         """Initialize global cursor.
@@ -533,6 +535,7 @@ class Cursor:
             name: Optional thread name (auto-generated from first message if not
                 provided)
             folder: Optional folder path for new threads (server support required)
+            user_agent: DataThread creation_user_agent — "API" or "Louie"
             _parent_trace_id: Internal parameter for inheriting trace context from
                 parent cursor. Do not use directly.
         """
@@ -613,6 +616,7 @@ class Cursor:
         self._share_mode: str = share_mode
         self._name: str | None = name
         self._folder: str | None = folder
+        self._user_agent: str = user_agent
         self._last_display_id: str | None = None
         # Session-level trace ID for correlating requests when OTel is not available
         self._trace_id: str = _parent_trace_id or generate_trace_id()
@@ -865,6 +869,7 @@ class Cursor:
                     agent=agent,
                     traces=use_traces,
                     share_mode=use_share_mode,
+                    user_agent=self._user_agent,
                     name=self._name,
                     folder=self._folder,
                     session_trace_id=self._trace_id,
@@ -886,6 +891,7 @@ class Cursor:
                     folder=self._folder,
                     traces=use_traces,
                     share_mode=use_share_mode,
+                    user_agent=self._user_agent,
                     session_trace_id=self._trace_id,
                 )
 

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -391,6 +391,7 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
     agent = kwargs.get("agent", "LouieAgent")
     traces = kwargs.get("traces", False)
     share_mode = kwargs.get("share_mode", "Private")
+    user_agent = kwargs.get("user_agent", "API")
     name = kwargs.get("name")
     folder = kwargs.get("folder")
     session_trace_id = kwargs.get("session_trace_id")
@@ -403,6 +404,7 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
         "query": prompt,
         "agent": agent,
         "ignore_traces": str(not traces).lower(),
+        "user_agent": user_agent,
         "share_mode": share_mode,
     }
 

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -510,10 +510,11 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
     if actual_thread_id and result["elements"]:
         for elem in result["elements"]:
             if elem.get("type") in ["DfElement", "df"]:
-                # Skip empty DataFrames — server GCs them before we can fetch
-                meta = elem.get("metadata", {})
-                shape = meta.get("shape", [])
+                shape = (elem.get("metadata") or {}).get("shape", [])
                 if shape and shape[0] == 0:
+                    # Workaround: server GCs empty DFs before fetch (#40)
+                    import pandas as pd
+                    elem["table"] = pd.DataFrame()
                     continue
 
                 # Try multiple possible field names for the dataframe ID

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -429,7 +429,9 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
 
     logger.debug(
         "stream_response: url=%s/api/chat/ timeout=%.0f read=%.0f params=%s",
-        client.server_url, overall_timeout, read_timeout,
+        client.server_url,
+        overall_timeout,
+        read_timeout,
         {k: v for k, v in params.items() if k != "query"},
     )
 
@@ -460,7 +462,9 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                     msg_type = data.get("type", "unknown")
                     logger.debug(
                         "stream_response: line %d type=%s keys=%s",
-                        lines_received, msg_type, list(data.keys())[:6],
+                        lines_received,
+                        msg_type,
+                        list(data.keys())[:6],
                     )
 
                     # Update display
@@ -495,7 +499,8 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                 except json.JSONDecodeError:
                     logger.warning(
                         "stream_response: line %d JSON decode error: %s",
-                        lines_received, line[:200],
+                        lines_received,
+                        line[:200],
                     )
                     continue
 
@@ -519,7 +524,9 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
 
     logger.info(
         "stream_response: done, lines=%d dthread=%s elements=%d",
-        lines_received, result["dthread_id"], len(elements_by_id),
+        lines_received,
+        result["dthread_id"],
+        len(elements_by_id),
     )
 
     # Final update
@@ -539,7 +546,8 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                 if shape and shape[0] == 0:
                     logger.debug(
                         "stream_response: skipping empty DF %s (shape=%s)",
-                        elem.get("id"), shape,
+                        elem.get("id"),
+                        shape,
                     )
                     continue
 

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -533,6 +533,16 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
     if actual_thread_id and result["elements"]:
         for elem in result["elements"]:
             if elem.get("type") in ["DfElement", "df"]:
+                # Skip empty DataFrames — server GCs them before we can fetch
+                meta = elem.get("metadata", {})
+                shape = meta.get("shape", [])
+                if shape and shape[0] == 0:
+                    logger.debug(
+                        "stream_response: skipping empty DF %s (shape=%s)",
+                        elem.get("id"), shape,
+                    )
+                    continue
+
                 # Try multiple possible field names for the dataframe ID
                 df_id = elem.get("df_id") or elem.get("block_id") or elem.get("id")
 

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -1,6 +1,7 @@
 """Streaming display support for Jupyter notebooks."""
 
 import json
+import logging
 import time
 from typing import Any
 
@@ -12,6 +13,8 @@ except ImportError:
     HAS_IPYTHON = False
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class StreamingDisplay:
@@ -418,23 +421,45 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
     result: dict[str, Any] = {"dthread_id": None, "elements": []}
     elements_by_id = {}
 
+    # Use client's timeout settings if available, otherwise defaults
+    overall_timeout = getattr(client, "_timeout", 600.0)
+    read_timeout = getattr(client, "_streaming_timeout", 300.0)
+
+    logger.debug(
+        "stream_response: url=%s/api/chat/ timeout=%.0f read=%.0f params=%s",
+        client.server_url, overall_timeout, read_timeout,
+        {k: v for k, v in params.items() if k != "query"},
+    )
+
     # Make streaming request
+    lines_received = 0
     try:
         with (
-            httpx.Client(timeout=httpx.Timeout(300.0, read=120.0)) as stream_client,
+            httpx.Client(
+                timeout=httpx.Timeout(overall_timeout, read=read_timeout)
+            ) as stream_client,
             stream_client.stream(
                 "POST", f"{client.server_url}/api/chat/", headers=headers, params=params
             ) as response,
         ):
             response.raise_for_status()
+            logger.debug("stream_response: connected, status=%d", response.status_code)
 
             # Process streaming lines
             for line in response.iter_lines():
                 if not line:
                     continue
 
+                lines_received += 1
+
                 try:
                     data = json.loads(line)
+
+                    msg_type = data.get("type", "unknown")
+                    logger.debug(
+                        "stream_response: line %d type=%s keys=%s",
+                        lines_received, msg_type, list(data.keys())[:6],
+                    )
 
                     # Update display
                     display_handler.update(data)
@@ -442,8 +467,6 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                     # Track data for result
                     if "dthread_id" in data:
                         result["dthread_id"] = data["dthread_id"]
-
-                    msg_type = data.get("type")
 
                     if msg_type == "StreamingApiMessageOutputUpdate":
                         elem = data.get("payload")
@@ -468,17 +491,34 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                                 elements_by_id[elem_id] = elem
 
                 except json.JSONDecodeError:
+                    logger.warning(
+                        "stream_response: line %d JSON decode error: %s",
+                        lines_received, line[:200],
+                    )
                     continue
 
     except httpx.ReadTimeout:
-        # This is expected - server keeps connection open
-        pass
+        import warnings
+
+        timeout_msg = (
+            f"Streaming timed out after {lines_received} lines "
+            f"(read_timeout={read_timeout:.0f}s). "
+            f"Increase streaming_timeout when creating LouieClient."
+        )
+        logger.warning("stream_response: %s", timeout_msg)
+        warnings.warn(timeout_msg, RuntimeWarning, stacklevel=2)
     except Exception as e:
+        logger.error("stream_response: error after %d lines: %s", lines_received, e)
         # Show error in display
         error_elem = {"id": "error", "type": "ExceptionElement", "message": str(e)}
         display_handler.elements_by_id["error"] = error_elem
         display_handler.finalize()
         raise
+
+    logger.info(
+        "stream_response: done, lines=%d dthread=%s elements=%d",
+        lines_received, result["dthread_id"], len(elements_by_id),
+    )
 
     # Final update
     display_handler.finalize()

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -1,7 +1,6 @@
 """Streaming display support for Jupyter notebooks."""
 
 import json
-import logging
 import time
 from typing import Any
 
@@ -13,8 +12,6 @@ except ImportError:
     HAS_IPYTHON = False
 
 import httpx
-
-logger = logging.getLogger(__name__)
 
 
 class StreamingDisplay:
@@ -427,14 +424,6 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
     overall_timeout = getattr(client, "_timeout", 600.0)
     read_timeout = getattr(client, "_streaming_timeout", 300.0)
 
-    logger.debug(
-        "stream_response: url=%s/api/chat/ timeout=%.0f read=%.0f params=%s",
-        client.server_url,
-        overall_timeout,
-        read_timeout,
-        {k: v for k, v in params.items() if k != "query"},
-    )
-
     # Make streaming request
     lines_received = 0
     try:
@@ -443,11 +432,13 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                 timeout=httpx.Timeout(overall_timeout, read=read_timeout)
             ) as stream_client,
             stream_client.stream(
-                "POST", f"{client.server_url}/api/chat/", headers=headers, params=params
+                "POST",
+                f"{client.server_url}/api/chat/",
+                headers=headers,
+                params=params,
             ) as response,
         ):
             response.raise_for_status()
-            logger.debug("stream_response: connected, status=%d", response.status_code)
 
             # Process streaming lines
             for line in response.iter_lines():
@@ -459,20 +450,14 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                 try:
                     data = json.loads(line)
 
-                    msg_type = data.get("type", "unknown")
-                    logger.debug(
-                        "stream_response: line %d type=%s keys=%s",
-                        lines_received,
-                        msg_type,
-                        list(data.keys())[:6],
-                    )
-
                     # Update display
                     display_handler.update(data)
 
                     # Track data for result
                     if "dthread_id" in data:
                         result["dthread_id"] = data["dthread_id"]
+
+                    msg_type = data.get("type")
 
                     if msg_type == "StreamingApiMessageOutputUpdate":
                         elem = data.get("payload")
@@ -497,11 +482,6 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                                 elements_by_id[elem_id] = elem
 
                 except json.JSONDecodeError:
-                    logger.warning(
-                        "stream_response: line %d JSON decode error: %s",
-                        lines_received,
-                        line[:200],
-                    )
                     continue
 
     except httpx.ReadTimeout:
@@ -512,22 +492,13 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
             f"(read_timeout={read_timeout:.0f}s). "
             f"Increase streaming_timeout when creating LouieClient."
         )
-        logger.warning("stream_response: %s", timeout_msg)
         warnings.warn(timeout_msg, RuntimeWarning, stacklevel=2)
     except Exception as e:
-        logger.error("stream_response: error after %d lines: %s", lines_received, e)
         # Show error in display
         error_elem = {"id": "error", "type": "ExceptionElement", "message": str(e)}
         display_handler.elements_by_id["error"] = error_elem
         display_handler.finalize()
         raise
-
-    logger.info(
-        "stream_response: done, lines=%d dthread=%s elements=%d",
-        lines_received,
-        result["dthread_id"],
-        len(elements_by_id),
-    )
 
     # Final update
     display_handler.finalize()
@@ -544,11 +515,6 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                 meta = elem.get("metadata", {})
                 shape = meta.get("shape", [])
                 if shape and shape[0] == 0:
-                    logger.debug(
-                        "stream_response: skipping empty DF %s (shape=%s)",
-                        elem.get("id"),
-                        shape,
-                    )
                     continue
 
                 # Try multiple possible field names for the dataframe ID

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -514,6 +514,7 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
                 if shape and shape[0] == 0:
                     # Workaround: server GCs empty DFs before fetch (#40)
                     import pandas as pd
+
                     elem["table"] = pd.DataFrame()
                     continue
 

--- a/src/louieai/notebook/streaming.py
+++ b/src/louieai/notebook/streaming.py
@@ -420,9 +420,8 @@ def stream_response(client, thread_id: str, prompt: str, **kwargs) -> dict[str, 
     result: dict[str, Any] = {"dthread_id": None, "elements": []}
     elements_by_id = {}
 
-    # Use client's timeout settings if available, otherwise defaults
-    overall_timeout = getattr(client, "_timeout", 600.0)
-    read_timeout = getattr(client, "_streaming_timeout", 300.0)
+    overall_timeout = client._timeout
+    read_timeout = client._streaming_timeout
 
     # Make streaming request
     lines_received = 0

--- a/tests/unit/notebook/test_streaming.py
+++ b/tests/unit/notebook/test_streaming.py
@@ -150,6 +150,8 @@ class TestStreamResponse:
         client.server_url = "https://test.louie.ai"
         client._get_headers.return_value = {"Authorization": "Bearer test"}
         client._fetch_dataframe_arrow.return_value = None
+        client._timeout = 600.0
+        client._streaming_timeout = 300.0
         return client
 
     def test_basic_streaming(self, mock_client):

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-04-02T23:28:24Z"
+
 [[package]]
 name = "anyio"
 version = "4.9.0"


### PR DESCRIPTION
## Streaming Timeout Fix
- `stream_response()` used hardcoded timeouts (300s overall, 120s read) — agent runs >120s between chunks returned empty `texts=[]`
- Now uses `client._timeout` / `client._streaming_timeout`
- Emits `RuntimeWarning` on timeout so users see it in notebook output

## Empty DataFrame Handling
- Skips fetching DfElements with `shape: [0,0]` to avoid `ArrowInvalid` warnings
- Server GCs empty query results before client can fetch Arrow data

## Cursor Metadata
- `user_agent` param ("API" | "Louie") → sets `creation_user_agent` on DataThread
- `folder` param → organizes threads into folders
- `frontend_url` param → override auto-detected thread URL
- Auto-detects desktop deep links (`louie://n/`) for localhost servers

## Types
- New `_types.py` with `ShareMode` and `UserAgent` Literal types
- Applied throughout `Cursor`, `LouieClient.add_cell()`, and `__init__.py`

## Closes
- Closes #33 — folder support and thread naming now work end-to-end

## Test plan
- [x] Run notebook query end-to-end — verify `lui.texts` is populated
- [x] Verify `user_agent="Louie"` shows in DataThread `creation_user_agent`
- [x] Verify `folder="commander"` organizes threads
- [x] Desktop URL produces `louie://n/D_xxx`, team URL produces web link
- [x] Empty DfElements (shape [0,0]) don't produce ArrowInvalid warnings
- [x] RuntimeWarning on timeout visible in notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)