### PR TITLE
fix: normalized elements view and final-answer resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Compatibility
 - Reasoning stays off by default. `Response.text` keeps its historical first-text fallback and Cursor keeps its latest-text fallback when the server has no explicit final-answer pointer.
 
+## [Unreleased]
+
+### Fixed
+- `ResponseProxy.elements` (`lui.elements`, `lui[-n].elements`, `Cursor.elements`) read a
+  `message` key for error text, but the server sends `ExceptionElement.text`, so every error
+  surfaced the literal `"Unknown error"` while the real message was dropped. Reads `text`
+  first, with `message` retained as a legacy fallback.
+- `ResponseProxy.elements` entries now carry the source element `id`, so they can be
+  correlated with `Response.final_answer_id`, and are emitted in server position order
+  instead of being regrouped by type (an error raised midway is no longer hoisted first).
+
+### Changed
+- **Breaking:** `Response.text` now honours the server's explicit `final_answer` pointer
+  whether or not `include_reasoning` was set. It previously did so only when reasoning was
+  requested, and otherwise returned the first text element. Affects responses where the
+  server names a final answer that is not the first text element. `final_text` was already
+  correct and is unchanged.
+- `Response.text_elements` now excludes reasoning, matching `Response.text` — the singular
+  and plural of the same accessor disagreed. Use `elements` for the unfiltered union or
+  `reasoning_elements` for reasoning. No effect unless `include_reasoning=True`.
+
+### Documentation
+- `docs/api/response-types.md` groups the 30 `Response` members into everyday, opt-in
+  reasoning, and power/debug tiers.
+
 ## [0.8.1] - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - `docs/api/response-types.md` groups the 30 `Response` members into everyday, opt-in
   reasoning, and power/debug tiers.
+- Point the advertised documentation URL at `louie-py.readthedocs.io`. `pyproject.toml`
+  and `CONTRIBUTING.md` linked `louieai.readthedocs.io`, which 404s, so the PyPI
+  "Documentation" link was broken on every release. The CONTRIBUTING troubleshooting
+  link pointed at a page that does not exist on either host and now points at the
+  authentication guide.
 
 ## [0.8.1] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-07-26
 
 ### Added
 - Default-off `include_reasoning` support across client, Cursor, Jupyter, and all upload paths.
@@ -13,14 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lossless `stream_messages`, run/phase/status/token, terminal, and returned `trace_events` accessors.
 
 ### Changed
+- **Breaking:** `Response.text` now honours the server's explicit `final_answer` pointer
+  whether or not `include_reasoning` was set. It previously did so only when reasoning was
+  requested, and otherwise returned the first text element. Affects responses where the
+  server names a final answer that is not the first text element. `final_text` was already
+  correct and is unchanged.
+- **Breaking:** `Response.text_elements` now excludes reasoning, matching `Response.text` —
+  the singular and plural of the same accessor disagreed. Use `elements` for the unfiltered
+  union or `reasoning_elements` for reasoning. No effect unless `include_reasoning=True`.
 - Streaming, singleshot, upload, and notebook paths now share typed/legacy/concatenated JSON accumulation with position-aware replacement.
 - Notebook displays label and collapse identifiable reasoning, show execution phase/status, and escape untrusted streamed HTML.
 - `traces` documentation now describes server trace events; provisional model reasoning uses `include_reasoning`.
-
-### Compatibility
-- Reasoning stays off by default. `Response.text` keeps its historical first-text fallback and Cursor keeps its latest-text fallback when the server has no explicit final-answer pointer.
-
-## [Unreleased]
 
 ### Fixed
 - `ResponseProxy.elements` (`lui.elements`, `lui[-n].elements`, `Cursor.elements`) read a
@@ -31,15 +34,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   correlated with `Response.final_answer_id`, and are emitted in server position order
   instead of being regrouped by type (an error raised midway is no longer hoisted first).
 
-### Changed
-- **Breaking:** `Response.text` now honours the server's explicit `final_answer` pointer
-  whether or not `include_reasoning` was set. It previously did so only when reasoning was
-  requested, and otherwise returned the first text element. Affects responses where the
-  server names a final answer that is not the first text element. `final_text` was already
-  correct and is unchanged.
-- `Response.text_elements` now excludes reasoning, matching `Response.text` — the singular
-  and plural of the same accessor disagreed. Use `elements` for the unfiltered union or
-  `reasoning_elements` for reasoning. No effect unless `include_reasoning=True`.
+### Compatibility
+- Reasoning stays off by default. `Response.text` keeps its historical first-text behaviour
+  when the server sends no explicit final-answer pointer, and Cursor keeps its latest-text
+  fallback.
+
+### Security
+- Both secret-detection gate modes were structurally unable to fail: they branched on the
+  exit code of `detect-secrets scan --baseline`, which is an update command that always
+  exits 0. Replaced with an explicit baseline comparison, and added a deterministic gate for
+  Graphistry personal keys that entropy heuristics do not reach.
+- Pre-commit now scans the git index rather than the working tree, honours renames, and
+  fails closed on a missing or corrupt baseline.
+- Development credentials referenced by tests have been rotated; test fixtures, docs, and
+  `.env.example` now use RFC 2606 example domains and public endpoints.
+
+### Internal
+- CI installs from `uv.lock` (`uv sync --locked`), so lint, format, and type results are
+  reproducible. Previously it resolved unpinned floors and silently drifted.
+- `.env` is opt-in for tests via `LOUIE_TEST_MODE=integration`, so a run with no credentials
+  stays offline instead of dialling a real service.
 
 ### Documentation
 - `docs/api/response-types.md` groups the 30 `Response` members into everyday, opt-in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,13 +101,13 @@ We follow our [Code of Conduct](CODE_OF_CONDUCT.md). Please read it.
 ## Where to Get Help
 
 ### 🤔 Questions?
-- Check our [documentation](https://louieai.readthedocs.io)
+- Check our [documentation](https://louie-py.readthedocs.io)
 - Search existing [issues](https://github.com/graphistry/louie-py/issues)
 - Open a [discussion](https://github.com/graphistry/louie-py/discussions)
 
 ### 🔧 Technical Setup?
 - See [DEVELOP.md](DEVELOP.md) for detailed instructions
-- Check [troubleshooting guide](https://louieai.readthedocs.io/en/latest/troubleshooting/)
+- Check the [authentication guide](https://louie-py.readthedocs.io/en/latest/guides/authentication/)
 - Ask in discussions - we're here to help!
 
 ### 🔒 Security Issues?

--- a/docs/api/response-types.md
+++ b/docs/api/response-types.md
@@ -48,6 +48,48 @@ for element in response.elements:
     print(f"Element type: {element_type}")
 ```
 
+## Response accessors: start here
+
+`Response` exposes a lot of surface. Almost all use falls in the first tier.
+
+### Everyday
+
+| Accessor | Type | Meaning |
+| --- | --- | --- |
+| `text` | `str \| None` | The answer |
+| `df` / `dfs` | DataFrame | First / all dataframes |
+| `status` | `str` | `"succeeded"`, `"failed"`, `"running"`, `"unknown"` |
+| `has_errors` / `errors` | `bool` / `list` | Element-level errors |
+| `terminal_error` | `str \| None` | Stream-level failure, distinct from `errors` |
+
+### Reasoning — opt-in
+
+Only populated when the request set `include_reasoning=True`; otherwise empty.
+
+| Accessor | Type | Meaning |
+| --- | --- | --- |
+| `reasoning_text` | `str \| None` | Provisional draft the agent produced while working |
+| `phases` | `list[dict]` | Progress steps |
+
+`text` never returns reasoning, whether or not you opt in — so enabling it
+cannot change what your existing code reads.
+
+### Power and debugging
+
+`final_text`, `final_texts`, `final_text_element`, `final_text_elements`,
+`final_answer_id`, `reasoning_texts`, `reasoning_elements`, `text_elements`,
+`run_nodes`, `root_run`, `run_updates`, `phase_updates`, `token_flow`,
+`terminals`, `terminal`, `succeeded`, `trace_events`, `stream_messages`,
+`dataframe_elements`, `graph_elements`.
+
+Two notes that catch people out:
+
+- **`text_elements` is the plural of `text`** — it excludes reasoning, exactly as
+  `text` does. For the unfiltered union use `elements`; for reasoning
+  specifically use `reasoning_elements`.
+- **`trace_events`** are server-emitted trace payloads requested via `traces=True`.
+  They are unrelated to W3C request tracing.
+
 ## Streaming envelopes and final-answer semantics
 
 Current streaming and singleshot routes return typed envelopes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 # Note: graphistry on PyPI is named 'graphistry'. We ensure a minimal version that likely includes Louie support.
 
 [project.urls]
-Documentation = "https://louieai.readthedocs.io"
+Documentation = "https://louie-py.readthedocs.io"
 Repository = "https://github.com/graphistry/louie-py"
 "Issue Tracker" = "https://github.com/graphistry/louie-py/issues"
 Changelog = "https://github.com/graphistry/louie-py/blob/main/CHANGELOG.md"

--- a/src/louieai/_client.py
+++ b/src/louieai/_client.py
@@ -71,7 +71,17 @@ class Response:
 
     @property
     def text_elements(self) -> list[dict[str, Any]]:
-        """Get all text elements, including opt-in reasoning elements."""
+        """Text outputs, excluding opt-in reasoning.
+
+        Matches :attr:`text`: singular and plural mean the same thing. For the
+        unfiltered view use :attr:`elements`; for reasoning specifically use
+        :attr:`reasoning_elements`.
+        """
+        return self.final_text_elements
+
+    @property
+    def _all_text_elements(self) -> list[dict[str, Any]]:
+        """Every text element, reasoning included. Basis for classification."""
         return [e for e in self.elements if e.get("type") in ["TextElement", "text"]]
 
     @property
@@ -243,7 +253,7 @@ class Response:
     @property
     def reasoning_elements(self) -> list[dict[str, Any]]:
         """Latest text snapshots classified as opt-in reasoning."""
-        return [e for e in self.text_elements if self._is_reasoning_element(e)]
+        return [e for e in self._all_text_elements if self._is_reasoning_element(e)]
 
     @property
     def reasoning_texts(self) -> list[str]:
@@ -259,7 +269,7 @@ class Response:
     @property
     def final_text_elements(self) -> list[dict[str, Any]]:
         """Text outputs excluding elements classified as reasoning."""
-        return [e for e in self.text_elements if not self._is_reasoning_element(e)]
+        return [e for e in self._all_text_elements if not self._is_reasoning_element(e)]
 
     @property
     def final_texts(self) -> list[str]:
@@ -287,12 +297,14 @@ class Response:
     def text(self) -> str | None:
         """Get the primary final-oriented text response.
 
-        An explicit server final-answer pointer wins. Without one, preserve the
+        An explicit server final-answer pointer always wins, whether or not
+        reasoning was requested: if the server names the final answer, returning
+        a different element is never right. Without a pointer, preserve the
         historical SDK behavior of returning the first text element, excluding
         only an old wire-format element explicitly marked ``draft=true``.
         """
         final_id = self.final_answer_id
-        if final_id and self.include_reasoning is True:
+        if final_id:
             element = self.final_text_element
             return self._element_text(element) if element is not None else None
         elements = self.final_text_elements

--- a/src/louieai/notebook/cursor.py
+++ b/src/louieai/notebook/cursor.py
@@ -494,31 +494,54 @@ class ResponseProxy:
 
     @property
     def elements(self) -> list[dict[str, Any]]:
-        """All elements with type tags."""
+        """All elements with type tags, in server position order.
+
+        Each entry carries the source element's ``id`` where the server supplied
+        one, so entries can be correlated with ``Response.final_answer_id``.
+        Entries are emitted in the order the server produced them rather than
+        grouped by type, so an error raised midway stays in position.
+        """
         if not self._response:
             return []
 
-        result = []
+        # Sub-views are filters over the same dict objects, so identity maps
+        # each entry back to its position in the server's output.
+        source = getattr(self._response, "elements", []) or []
+        positions = {id(elem): index for index, elem in enumerate(source)}
+        unplaced = len(positions)
+        ordered: list[tuple[int, dict[str, Any]]] = []
+
+        def tag(elem: Any, entry: dict[str, Any]) -> None:
+            if isinstance(elem, dict) and elem.get("id") is not None:
+                entry.setdefault("id", elem["id"])
+            ordered.append((positions.get(id(elem), unplaced), entry))
 
         for elem in self.errors:
-            result.append(
+            # Current servers send ExceptionElement.text; `message` is legacy.
+            value = (
+                elem.get("text")
+                or elem.get("message")
+                or elem.get("value")
+                or "Unknown error"
+            )
+            tag(
+                elem,
                 {
                     "type": "error",
-                    "value": elem.get("message", "Unknown error"),
+                    "value": value,
                     "error_type": elem.get("error_type"),
                     "traceback": elem.get("traceback"),
-                }
+                },
             )
 
         for elem in self.final_text_elements:
             value = elem.get("content") or elem.get("text", "") or elem.get("value", "")
-            result.append({"type": "text", "value": value})
+            tag(elem, {"type": "text", "value": value})
 
         for elem in self.reasoning_elements:
             value = elem.get("content") or elem.get("text", "") or elem.get("value", "")
-            result.append({"type": "reasoning", "value": value})
+            tag(elem, {"type": "reasoning", "value": value})
 
-        # Add dataframe elements
         if (
             hasattr(self._response, "dataframe_elements")
             and self._response.dataframe_elements
@@ -530,18 +553,17 @@ class ResponseProxy:
                         "value": elem["table"],  # Backward compatibility
                         "df": elem["table"],  # Convenient access as 'df'
                     }
-                    # Include metadata from the original element
                     for key in ["id", "df_id", "block_id"]:
                         if key in elem:
                             df_element[key] = elem[key]
-                    result.append(df_element)
+                    tag(elem, df_element)
 
-        # Add graph elements
         if hasattr(self._response, "graph_elements") and self._response.graph_elements:
             for elem in self._response.graph_elements:
-                result.append({"type": "graph", "value": elem})
+                tag(elem, {"type": "graph", "value": elem})
 
-        return result
+        ordered.sort(key=lambda pair: pair[0])
+        return [entry for _, entry in ordered]
 
     @property
     def errors(self) -> list[dict[str, Any]]:

--- a/tests/unit/notebook/test_elements_normalized_view.py
+++ b/tests/unit/notebook/test_elements_normalized_view.py
@@ -1,0 +1,150 @@
+"""Regression tests for the normalized `ResponseProxy.elements` view.
+
+Two defects, both in this one function:
+
+1. Error text always read a `message` key. Current servers send
+   `ExceptionElement.text` (`graphistrygpt/models/elements.py`), so every
+   error surfaced the literal "Unknown error" while the real message sat
+   unread in the element.
+2. Entries dropped the element `id` and were regrouped by type, so nothing
+   could be correlated with `Response.final_answer_id` and an error raised
+   midway was hoisted to the front.
+
+Neither affected `text`, `final_text`, or the raw `errors` list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from louieai._client import Response
+from louieai.notebook.cursor import ResponseProxy
+
+pytestmark = pytest.mark.unit
+
+
+def _run_msgs(final_answer: str, run_id: str = "R_root") -> list[dict]:
+    return [
+        {
+            "type": "StreamingApiMessageRunUpdate",
+            "run_node": {
+                "node_type": "Run",
+                "id": run_id,
+                "state": "Done",
+                "final_answer": final_answer,
+            },
+        }
+    ]
+
+
+def test_exception_element_text_is_surfaced() -> None:
+    """Current wire format: ExceptionElement carries `text`, not `message`."""
+    response = Response(
+        "D", [{"id": "B_e", "type": "ExceptionElement", "text": "division by zero"}]
+    )
+
+    entry = ResponseProxy(response).elements[0]
+
+    assert entry["type"] == "error"
+    assert entry["value"] == "division by zero"
+
+
+def test_legacy_message_key_still_surfaced() -> None:
+    """Older elements used `message`; it remains a fallback."""
+    response = Response(
+        "D", [{"id": "B_e", "type": "ExceptionElement", "message": "legacy boom"}]
+    )
+
+    assert ResponseProxy(response).elements[0]["value"] == "legacy boom"
+
+
+def test_text_wins_over_legacy_message_when_both_present() -> None:
+    """Precedence, not just presence.
+
+    Tests that supply only one key pass regardless of ordering, so they do not
+    pin which field wins. `text` is the current wire format and must take
+    precedence over the legacy `message`.
+    """
+    response = Response(
+        "D",
+        [
+            {
+                "id": "B_e",
+                "type": "ExceptionElement",
+                "text": "current wire format",
+                "message": "legacy field",
+            }
+        ],
+    )
+
+    assert ResponseProxy(response).elements[0]["value"] == "current wire format"
+
+
+def test_unknown_error_only_when_nothing_available() -> None:
+    response = Response("D", [{"id": "B_e", "type": "ExceptionElement"}])
+
+    assert ResponseProxy(response).elements[0]["value"] == "Unknown error"
+
+
+def test_entries_expose_id_and_match_final_answer_id() -> None:
+    """Entries must be correlatable with the root run's final-answer pointer."""
+    response = Response(
+        "D",
+        [
+            {
+                "id": "B_1",
+                "type": "TextElement",
+                "text": "thinking",
+                "during_run_id": "R_root",
+            },
+            {
+                "id": "B_2",
+                "type": "TextElement",
+                "text": "the answer",
+                "during_run_id": "R_root",
+            },
+        ],
+        stream_messages=_run_msgs("B_2"),
+        include_reasoning=True,
+    )
+
+    entries = ResponseProxy(response).elements
+
+    assert all("id" in entry for entry in entries)
+    matched = [e for e in entries if e["id"] == response.final_answer_id]
+    assert [e["type"] for e in matched] == ["text"]
+    assert matched[0]["value"] == "the answer"
+
+
+def test_entries_keep_server_position_order() -> None:
+    """An error raised midway must not be hoisted to the front."""
+    response = Response(
+        "D",
+        [
+            {
+                "id": "B_1",
+                "type": "TextElement",
+                "text": "step one done",
+                "during_run_id": "R_root",
+            },
+            {"id": "B_2", "type": "ExceptionElement", "text": "boom"},
+            {
+                "id": "B_3",
+                "type": "TextElement",
+                "text": "final answer",
+                "during_run_id": "R_root",
+            },
+        ],
+        stream_messages=_run_msgs("B_3"),
+        include_reasoning=True,
+    )
+
+    entries = ResponseProxy(response).elements
+
+    assert [e["id"] for e in entries] == ["B_1", "B_2", "B_3"]
+    assert [e["type"] for e in entries] == ["reasoning", "error", "text"]
+
+
+def test_empty_response_returns_empty_list() -> None:
+    assert ResponseProxy(None).elements == []
+    assert ResponseProxy(Response("D", [])).elements == []

--- a/tests/unit/notebook/test_reasoning_api.py
+++ b/tests/unit/notebook/test_reasoning_api.py
@@ -82,10 +82,14 @@ def test_response_cursor_and_history_have_reasoning_metadata_parity() -> None:
     assert cursor.status == "succeeded"
     assert cursor.traces is False
     assert cursor.trace_events == [[20, 1, "done"]]
+    # Server position order: B_reason precedes B_final on the wire. The previous
+    # expectation ("text", "reasoning") encoded a defect — entries were grouped
+    # by type, hoisting the final answer ahead of reasoning that arrived first.
     assert [element["type"] for element in cursor.elements] == [
-        "text",
         "reasoning",
+        "text",
     ]
+    assert [element["id"] for element in cursor.elements] == ["B_reason", "B_final"]
 
 
 def test_cursor_texts_keep_tool_output_but_follow_explicit_final_pointer() -> None:

--- a/tests/unit/test_reasoning_response.py
+++ b/tests/unit/test_reasoning_response.py
@@ -242,7 +242,7 @@ def test_legacy_draft_flag_remains_supported() -> None:
     assert response.reasoning_text == "draft"
 
 
-def test_default_off_preserves_legacy_multi_root_text_semantics() -> None:
+def test_explicit_final_answer_pointer_wins_even_when_reasoning_is_off() -> None:
     response = Response(
         "D_legacy",
         [
@@ -273,7 +273,11 @@ def test_default_off_preserves_legacy_multi_root_text_semantics() -> None:
         include_reasoning=False,
     )
 
-    assert response.text == "first legitimate output"
+    # BREAKING (unreleased): `.text` previously returned the first text element
+    # here, ignoring the server's explicit final_answer pointer unless
+    # include_reasoning was set. A pointer is the server stating which element
+    # is the answer, so honouring it conditionally was indefensible.
+    assert response.text == "second legitimate output"
     assert response.final_text == "second legitimate output"
     assert response.final_texts == [
         "first legitimate output",
@@ -360,3 +364,47 @@ def test_singleshot_uses_same_typed_accumulator() -> None:
     assert response.text == "final answer"
     assert response.status == "succeeded"
     assert response.reasoning_text == "checking the evidence"
+
+
+def test_text_elements_matches_text_semantics() -> None:
+    """`text_elements` is the plural of `text`, not the raw union.
+
+    Previously `.text` excluded reasoning while `.text_elements` included it, so
+    the singular and plural of the same word disagreed. The unfiltered view is
+    `.elements`; reasoning specifically is `.reasoning_elements`.
+    """
+    response = Response(
+        "D_split",
+        [
+            {
+                "id": "B_draft",
+                "type": "TextElement",
+                "text": "thinking",
+                "during_run_id": "R_root",
+            },
+            {
+                "id": "B_final",
+                "type": "TextElement",
+                "text": "answer",
+                "during_run_id": "R_root",
+            },
+        ],
+        stream_messages=[
+            {
+                "type": "StreamingApiMessageRunUpdate",
+                "run_node": {
+                    "node_type": "Run",
+                    "id": "R_root",
+                    "state": "Done",
+                    "final_answer": "B_final",
+                },
+            }
+        ],
+        include_reasoning=True,
+    )
+
+    assert [e["id"] for e in response.text_elements] == ["B_final"]
+    assert response.text_elements == response.final_text_elements
+    assert [e["id"] for e in response.reasoning_elements] == ["B_draft"]
+    # The raw union remains reachable.
+    assert len(response.elements) == 2


### PR DESCRIPTION
Reported by colleagues against `main@d0eedbd`. Both bugs reproduced offline before fixing; both fixes mutation-verified (reverting either fails a test).

## 1. `ResponseProxy.elements` — error text was always `"Unknown error"`

It read a `message` key, but the server's `ExceptionElement` carries `text` — there is no `message` and no `error_type` field. So every current-server error showed the placeholder while the real message sat unread.

```
before: {'type':'error', 'value':'Unknown error'}
after:  {'type':'error', 'value':'division by zero', 'id':'B_e'}
```

`text` first, `message` kept as legacy fallback.

## 2. `ResponseProxy.elements` — dropped IDs, regrouped by type

Entries omitted `id` (so nothing could be correlated with `final_answer_id`, while the dataframe branch *did* copy it), and were emitted errors → texts → reasoning, hoisting a mid-run error to the front.

```
server order:  B_1 text, B_2 error, B_3 text
before:        error | text | reasoning        (no ids)
after:         B_1 reasoning | B_2 error | B_3 text
```

Sub-views are filters over the same dict objects, so an identity→position map restores order without touching value extraction.

## 3. `Response.text` honours `final_answer` unconditionally — **BREAKING**

`.text` consulted the server's explicit `final_answer` pointer only when `include_reasoning` was set; otherwise it returned the first text element. If the server names the answer, returning a different element isn't defensible.

Affects responses where the pointer isn't the first text element. `final_text` was already correct. Unreleased — `include_reasoning` has never shipped.

## 4. `text_elements` matches `text`

The singular excluded reasoning, the plural didn't. Now consistent. `elements` remains the unfiltered union; `reasoning_elements` the reasoning view. No effect unless `include_reasoning=True`.

Classification moved to a private `_all_text_elements` — both filtered views derive from it, so aliasing directly would have recursed infinitely.

## Tests

7 new in `tests/unit/notebook/test_elements_normalized_view.py`, covering the four cases suggested in the report plus `text`-over-`message` precedence — my first pass supplied only one key at a time, so precedence was unpinned and the fix survived mutation until I added it.

One existing assertion expected `("text", "reasoning")` for a fixture whose reasoning element is at wire position 0 — it encoded the defect, and is updated with a note.

## Validation

**607 passed, 5 skipped, 87.10%** coverage; lint, format, mypy, secret detection, `uv lock --check`, strict docs, and credential-free integration (30 passed / 26 skipped) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyiG851jxkDkqB5u9gnpox